### PR TITLE
Add SkinShuffle integration across supported platforms

### DIFF
--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/SRBukkitInit.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/SRBukkitInit.java
@@ -189,8 +189,11 @@ public class SRBukkitInit implements SRServerPlatformInit {
     }
 
     @Override
-    public void initClientCompatibility() {
-        server.getPluginManager().registerEvents(injector.getSingleton(SkinShuffleJoinListener.class), adapter.getPluginInstance());
+    public void initClientCompatibility(boolean proxyMode) {
+        if (!proxyMode) {
+            server.getPluginManager().registerEvents(injector.getSingleton(SkinShuffleJoinListener.class), adapter.getPluginInstance());
+        }
+
         server.getMessenger().registerOutgoingPluginChannel(adapter.getPluginInstance(), SRHelpers.MESSAGE_CHANNEL);
         server.getMessenger().registerOutgoingPluginChannel(adapter.getPluginInstance(), SkinShuffleChannels.HANDSHAKE);
         server.getMessenger().registerOutgoingPluginChannel(adapter.getPluginInstance(), SkinShuffleChannels.REFRESH_PLAYER_LIST_ENTRY);

--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/SRBukkitInit.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/SRBukkitInit.java
@@ -34,6 +34,7 @@ import net.skinsrestorer.miniplaceholders.SRMiniPlaceholdersAPIExpansion;
 import net.skinsrestorer.shared.config.AdvancedConfig;
 import net.skinsrestorer.shared.info.ClassInfo;
 import net.skinsrestorer.shared.info.PluginInfo;
+import net.skinsrestorer.shared.integration.skinshuffle.SkinShuffleChannels;
 import net.skinsrestorer.shared.log.SRChatColor;
 import net.skinsrestorer.shared.log.SRLogLevel;
 import net.skinsrestorer.shared.log.SRLogger;
@@ -188,6 +189,16 @@ public class SRBukkitInit implements SRServerPlatformInit {
     }
 
     @Override
+    public void initClientCompatibility() {
+        server.getPluginManager().registerEvents(injector.getSingleton(SkinShuffleJoinListener.class), adapter.getPluginInstance());
+        server.getMessenger().registerOutgoingPluginChannel(adapter.getPluginInstance(), SRHelpers.MESSAGE_CHANNEL);
+        server.getMessenger().registerOutgoingPluginChannel(adapter.getPluginInstance(), SkinShuffleChannels.HANDSHAKE);
+        server.getMessenger().registerOutgoingPluginChannel(adapter.getPluginInstance(), SkinShuffleChannels.REFRESH_PLAYER_LIST_ENTRY);
+        server.getMessenger().registerIncomingPluginChannel(adapter.getPluginInstance(), SkinShuffleChannels.SKIN_REFRESH,
+                injector.getSingleton(SkinShuffleMessageListener.class));
+    }
+
+    @Override
     public void checkPluginSupport() {
         checkViaVersion();
 
@@ -285,7 +296,6 @@ public class SRBukkitInit implements SRServerPlatformInit {
 
     @Override
     public void initMessageChannel() {
-        server.getMessenger().registerOutgoingPluginChannel(adapter.getPluginInstance(), SRHelpers.MESSAGE_CHANNEL);
         server.getMessenger().registerIncomingPluginChannel(adapter.getPluginInstance(), SRHelpers.MESSAGE_CHANNEL,
                 injector.getSingleton(ServerMessageListener.class));
     }

--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/SkinApplierBukkit.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/SkinApplierBukkit.java
@@ -29,6 +29,9 @@ import net.skinsrestorer.shared.api.SkinApplierAccess;
 import net.skinsrestorer.shared.api.event.EventBusImpl;
 import net.skinsrestorer.shared.api.event.SkinApplyEventImpl;
 import net.skinsrestorer.shared.config.AdvancedConfig;
+import net.skinsrestorer.shared.config.ServerConfig;
+import net.skinsrestorer.shared.integration.skinshuffle.SkinShuffleChannels;
+import net.skinsrestorer.shared.integration.skinshuffle.SkinShuffleWire;
 import net.skinsrestorer.shared.utils.ReflectionUtil;
 import org.bukkit.Location;
 import org.bukkit.Server;
@@ -92,6 +95,7 @@ public class SkinApplierBukkit implements SkinApplierAccess<Player> {
 
         // Refresh the players own skin
         refresh.refresh(player, property);
+        refreshSkinShufflePlayerEntries(player);
     }
 
     private void normalOtherRefresh(Player player) {
@@ -153,5 +157,21 @@ public class SkinApplierBukkit implements SkinApplierAccess<Player> {
         } catch (Throwable e) { // Catch all errors and fallback to bukkit
             return server.getOnlinePlayers();
         }
+    }
+
+    private void refreshSkinShufflePlayerEntries(Player player) {
+        if (!settingsManager.getProperty(ServerConfig.SKINSHUFFLE_SUPPORT)) {
+            return;
+        }
+
+        byte[] payload = SkinShuffleWire.createRefreshPlayerListEntryPayload(player.getEntityId());
+        for (Player otherPlayer : getSeenByPlayers(player)) {
+            sendSkinShufflePacket(otherPlayer, SkinShuffleChannels.REFRESH_PLAYER_LIST_ENTRY, payload);
+        }
+        sendSkinShufflePacket(player, SkinShuffleChannels.REFRESH_PLAYER_LIST_ENTRY, payload);
+    }
+
+    private void sendSkinShufflePacket(Player player, String channel, byte[] payload) {
+        player.sendPluginMessage(adapter.getPluginInstance(), channel, payload);
     }
 }

--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/listener/SkinShuffleJoinListener.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/listener/SkinShuffleJoinListener.java
@@ -20,6 +20,7 @@ package net.skinsrestorer.bukkit.listener;
 import ch.jalu.configme.SettingsManager;
 import lombok.RequiredArgsConstructor;
 import net.skinsrestorer.bukkit.SRBukkitAdapter;
+import net.skinsrestorer.bukkit.utils.SchedulerProvider;
 import net.skinsrestorer.shared.config.ServerConfig;
 import net.skinsrestorer.shared.integration.skinshuffle.SkinShuffleChannels;
 import net.skinsrestorer.shared.integration.skinshuffle.SkinShuffleWire;
@@ -31,7 +32,9 @@ import javax.inject.Inject;
 
 @RequiredArgsConstructor(onConstructor_ = @Inject)
 public class SkinShuffleJoinListener implements Listener {
+    private static final long HANDSHAKE_DELAY_TICKS = 20L;
     private final SRBukkitAdapter adapter;
+    private final SchedulerProvider scheduler;
     private final SettingsManager settings;
 
     @EventHandler
@@ -40,8 +43,14 @@ public class SkinShuffleJoinListener implements Listener {
             return;
         }
 
-        event.getPlayer().sendPluginMessage(adapter.getPluginInstance(),
-                SkinShuffleChannels.HANDSHAKE,
-                SkinShuffleWire.createHandshakePayload());
+        scheduler.runSyncToEntityDelayed(event.getPlayer(), () -> {
+            if (!event.getPlayer().isOnline()) {
+                return;
+            }
+
+            event.getPlayer().sendPluginMessage(adapter.getPluginInstance(),
+                    SkinShuffleChannels.HANDSHAKE,
+                    SkinShuffleWire.createHandshakePayload());
+        }, HANDSHAKE_DELAY_TICKS);
     }
 }

--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/listener/SkinShuffleJoinListener.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/listener/SkinShuffleJoinListener.java
@@ -1,0 +1,47 @@
+/*
+ * SkinsRestorer
+ * Copyright (C) 2026  SkinsRestorer Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.skinsrestorer.bukkit.listener;
+
+import ch.jalu.configme.SettingsManager;
+import lombok.RequiredArgsConstructor;
+import net.skinsrestorer.bukkit.SRBukkitAdapter;
+import net.skinsrestorer.shared.config.ServerConfig;
+import net.skinsrestorer.shared.integration.skinshuffle.SkinShuffleChannels;
+import net.skinsrestorer.shared.integration.skinshuffle.SkinShuffleWire;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+import javax.inject.Inject;
+
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class SkinShuffleJoinListener implements Listener {
+    private final SRBukkitAdapter adapter;
+    private final SettingsManager settings;
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        if (!settings.getProperty(ServerConfig.SKINSHUFFLE_SUPPORT)) {
+            return;
+        }
+
+        event.getPlayer().sendPluginMessage(adapter.getPluginInstance(),
+                SkinShuffleChannels.HANDSHAKE,
+                SkinShuffleWire.createHandshakePayload());
+    }
+}

--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/listener/SkinShuffleMessageListener.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/listener/SkinShuffleMessageListener.java
@@ -1,0 +1,43 @@
+/*
+ * SkinsRestorer
+ * Copyright (C) 2026  SkinsRestorer Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.skinsrestorer.bukkit.listener;
+
+import lombok.RequiredArgsConstructor;
+import net.skinsrestorer.bukkit.wrapper.WrapperBukkit;
+import net.skinsrestorer.shared.integration.skinshuffle.SkinShuffleChannels;
+import net.skinsrestorer.shared.integration.skinshuffle.SkinShuffleSupport;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.messaging.PluginMessageListener;
+import org.jetbrains.annotations.NotNull;
+
+import javax.inject.Inject;
+
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class SkinShuffleMessageListener implements PluginMessageListener {
+    private final WrapperBukkit wrapper;
+    private final SkinShuffleSupport skinShuffleSupport;
+
+    @Override
+    public void onPluginMessageReceived(@NotNull String channel, @NotNull Player player, byte @NotNull [] message) {
+        if (!SkinShuffleChannels.SKIN_REFRESH.equals(channel)) {
+            return;
+        }
+
+        skinShuffleSupport.handleSkinRefresh(wrapper.player(player), message);
+    }
+}

--- a/bukkit/src/test/java/net/skinsrestorer/LoadTest.java
+++ b/bukkit/src/test/java/net/skinsrestorer/LoadTest.java
@@ -33,6 +33,7 @@ import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.command.SimpleCommandMap;
 import org.bukkit.plugin.SimplePluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.plugin.messaging.Messenger;
 import org.bukkit.scheduler.BukkitScheduler;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -92,6 +93,7 @@ class LoadTest {
             SimplePluginManager pluginManager = mock(SimplePluginManager.class);
             when(pluginManager.getPlugins()).thenReturn(new JavaPlugin[0]);
             when(server.getPluginManager()).thenReturn(pluginManager);
+            when(server.getMessenger()).thenReturn(mock(Messenger.class));
             when(server.getUpdateFolderFile()).thenReturn(tempDir.toFile());
 
             Bukkit.setServer(server);

--- a/bungee/src/main/java/net/skinsrestorer/bungee/SRBungeeInit.java
+++ b/bungee/src/main/java/net/skinsrestorer/bungee/SRBungeeInit.java
@@ -24,7 +24,10 @@ import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.skinsrestorer.bungee.listeners.AdminInfoListener;
 import net.skinsrestorer.bungee.listeners.LoginListener;
 import net.skinsrestorer.bungee.listeners.ProxyMessageListener;
+import net.skinsrestorer.bungee.listeners.SkinShuffleHandshakeListener;
+import net.skinsrestorer.bungee.listeners.SkinShuffleProxyMessageListener;
 import net.skinsrestorer.bungee.wrapper.WrapperBungee;
+import net.skinsrestorer.shared.integration.skinshuffle.SkinShuffleChannels;
 import net.skinsrestorer.shared.plugin.SRPlugin;
 import net.skinsrestorer.shared.plugin.SRProxyPlatformInit;
 import net.skinsrestorer.shared.plugin.SRProxyPluginSupportChecker;
@@ -59,11 +62,16 @@ public class SRBungeeInit implements SRProxyPlatformInit {
     @Override
     public void initAdminInfoListener() {
         proxy.getPluginManager().registerListener(adapter.getPluginInstance(), injector.newInstance(AdminInfoListener.class));
+        proxy.getPluginManager().registerListener(adapter.getPluginInstance(), injector.newInstance(SkinShuffleHandshakeListener.class));
     }
 
     @Override
     public void initMessageChannel() {
         proxy.registerChannel(SRHelpers.MESSAGE_CHANNEL);
+        proxy.registerChannel(SkinShuffleChannels.SKIN_REFRESH);
+        proxy.registerChannel(SkinShuffleChannels.HANDSHAKE);
+        proxy.registerChannel(SkinShuffleChannels.REFRESH_PLAYER_LIST_ENTRY);
         proxy.getPluginManager().registerListener(adapter.getPluginInstance(), injector.getSingleton(ProxyMessageListener.class));
+        proxy.getPluginManager().registerListener(adapter.getPluginInstance(), injector.getSingleton(SkinShuffleProxyMessageListener.class));
     }
 }

--- a/bungee/src/main/java/net/skinsrestorer/bungee/listeners/SkinShuffleHandshakeListener.java
+++ b/bungee/src/main/java/net/skinsrestorer/bungee/listeners/SkinShuffleHandshakeListener.java
@@ -1,0 +1,44 @@
+/*
+ * SkinsRestorer
+ * Copyright (C) 2026  SkinsRestorer Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.skinsrestorer.bungee.listeners;
+
+import ch.jalu.configme.SettingsManager;
+import lombok.RequiredArgsConstructor;
+import net.md_5.bungee.api.event.ServerConnectedEvent;
+import net.md_5.bungee.api.plugin.Listener;
+import net.md_5.bungee.event.EventHandler;
+import net.md_5.bungee.event.EventPriority;
+import net.skinsrestorer.shared.config.ServerConfig;
+import net.skinsrestorer.shared.integration.skinshuffle.SkinShuffleChannels;
+import net.skinsrestorer.shared.integration.skinshuffle.SkinShuffleWire;
+
+import javax.inject.Inject;
+
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class SkinShuffleHandshakeListener implements Listener {
+    private final SettingsManager settings;
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onServerConnected(ServerConnectedEvent event) {
+        if (!settings.getProperty(ServerConfig.SKINSHUFFLE_SUPPORT)) {
+            return;
+        }
+
+        event.getPlayer().sendData(SkinShuffleChannels.HANDSHAKE, SkinShuffleWire.createHandshakePayload());
+    }
+}

--- a/bungee/src/main/java/net/skinsrestorer/bungee/listeners/SkinShuffleProxyMessageListener.java
+++ b/bungee/src/main/java/net/skinsrestorer/bungee/listeners/SkinShuffleProxyMessageListener.java
@@ -1,0 +1,52 @@
+/*
+ * SkinsRestorer
+ * Copyright (C) 2026  SkinsRestorer Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.skinsrestorer.bungee.listeners;
+
+import lombok.RequiredArgsConstructor;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.connection.Server;
+import net.md_5.bungee.api.event.PluginMessageEvent;
+import net.md_5.bungee.api.plugin.Listener;
+import net.md_5.bungee.event.EventHandler;
+import net.skinsrestorer.bungee.wrapper.WrapperBungee;
+import net.skinsrestorer.shared.integration.skinshuffle.SkinShuffleChannels;
+import net.skinsrestorer.shared.integration.skinshuffle.SkinShuffleSupport;
+
+import javax.inject.Inject;
+
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class SkinShuffleProxyMessageListener implements Listener {
+    private final WrapperBungee wrapper;
+    private final SkinShuffleSupport skinShuffleSupport;
+
+    @EventHandler
+    public void onPluginMessage(PluginMessageEvent event) {
+        if (!SkinShuffleChannels.SKIN_REFRESH.equals(event.getTag())) {
+            return;
+        }
+        if (!(event.getSender() instanceof ProxiedPlayer player) || !(event.getReceiver() instanceof Server)) {
+            return;
+        }
+        if (!skinShuffleSupport.isEnabled()) {
+            return;
+        }
+
+        event.setCancelled(true);
+        skinShuffleSupport.handleSkinRefresh(wrapper.player(player), event.getData());
+    }
+}

--- a/mod/common/src/main/java/net/skinsrestorer/mod/SRModInit.java
+++ b/mod/common/src/main/java/net/skinsrestorer/mod/SRModInit.java
@@ -72,28 +72,29 @@ public class SRModInit implements SRServerPlatformInit {
     }
 
     @Override
-    public void initClientCompatibility() {
+    public void initClientCompatibility(boolean proxyMode) {
         SkinShuffleSupport skinShuffleSupport = injector.getSingleton(SkinShuffleSupport.class);
-        SRModPlatform.INSTANCE.initMessageChannel(SkinShuffleHandshakePayload.TYPE, SkinShuffleHandshakePayload.STREAM_CODEC,
-                (payload, player) -> {
-                });
-        SRModPlatform.INSTANCE.initMessageChannel(SkinShuffleRefreshPlayerListEntryPayload.TYPE, SkinShuffleRefreshPlayerListEntryPayload.STREAM_CODEC,
-                (payload, player) -> {
-                });
-        SRModPlatform.INSTANCE.initMessageChannel(SkinShuffleSkinRefreshPayload.TYPE, SkinShuffleSkinRefreshPayload.STREAM_CODEC,
+        SRModPlatform.INSTANCE.initClientboundMessageChannel(
+                SkinShuffleHandshakePayload.TYPE, SkinShuffleHandshakePayload.STREAM_CODEC);
+        SRModPlatform.INSTANCE.initClientboundMessageChannel(
+                SkinShuffleRefreshPlayerListEntryPayload.TYPE, SkinShuffleRefreshPlayerListEntryPayload.STREAM_CODEC);
+        SRModPlatform.INSTANCE.initServerboundMessageChannel(
+                SkinShuffleSkinRefreshPayload.TYPE, SkinShuffleSkinRefreshPayload.STREAM_CODEC,
                 (payload, player) -> payload.toSkinProperty().ifPresentOrElse(
                         property -> skinShuffleSupport.handleSkinRefresh(wrapper.player(player), property),
                         () -> logger.warning("Ignoring invalid SkinShuffle skin refresh payload from %s (%s)."
                                 .formatted(player.getGameProfile().name(), player.getGameProfile().id()))
                 ));
 
-        SRModPlatform.INSTANCE.registerPlayerJoinListener(player -> {
-            if (!skinShuffleSupport.isEnabled() || !SRModPlatform.INSTANCE.canSend(player, SkinShuffleHandshakePayload.TYPE)) {
-                return;
-            }
+        if (!proxyMode) {
+            SRModPlatform.INSTANCE.registerPlayerJoinListener(player -> {
+                if (!skinShuffleSupport.isEnabled() || !SRModPlatform.INSTANCE.canSend(player, SkinShuffleHandshakePayload.TYPE)) {
+                    return;
+                }
 
-            SRModPlatform.INSTANCE.sendPluginMessage(player, SkinShuffleHandshakePayload.INSTANCE);
-        });
+                SRModPlatform.INSTANCE.sendPluginMessage(player, SkinShuffleHandshakePayload.INSTANCE);
+            });
+        }
     }
 
     @Override
@@ -169,7 +170,7 @@ public class SRModInit implements SRServerPlatformInit {
     @Override
     public void initMessageChannel() {
         SRServerMessageAdapter messageAdapter = injector.getSingleton(SRServerMessageAdapter.class);
-        SRModPlatform.INSTANCE.initMessageChannel(SR_MESSAGE_CHANNEL, RawBytePayload.STREAM_CODEC,
+        SRModPlatform.INSTANCE.initBidirectionalMessageChannel(SR_MESSAGE_CHANNEL, RawBytePayload.STREAM_CODEC,
                 (payload, player) -> messageAdapter.handlePluginMessage(new SRServerMessageEvent() {
                     @Override
                     public SRServerPlayer getPlayer() {

--- a/mod/common/src/main/java/net/skinsrestorer/mod/SRModInit.java
+++ b/mod/common/src/main/java/net/skinsrestorer/mod/SRModInit.java
@@ -30,9 +30,13 @@ import net.skinsrestorer.api.semver.SemanticVersion;
 import net.skinsrestorer.miniplaceholders.SRMiniPlaceholdersAPIExpansion;
 import net.skinsrestorer.mod.listener.AdminInfoListener;
 import net.skinsrestorer.mod.listener.PlayerJoinListener;
+import net.skinsrestorer.mod.skinshuffle.SkinShuffleHandshakePayload;
+import net.skinsrestorer.mod.skinshuffle.SkinShuffleRefreshPlayerListEntryPayload;
+import net.skinsrestorer.mod.skinshuffle.SkinShuffleSkinRefreshPayload;
 import net.skinsrestorer.mod.wrapper.ModComponentHelper;
 import net.skinsrestorer.mod.wrapper.WrapperMod;
 import net.skinsrestorer.shared.info.PluginInfo;
+import net.skinsrestorer.shared.integration.skinshuffle.SkinShuffleSupport;
 import net.skinsrestorer.shared.listeners.SRServerMessageAdapter;
 import net.skinsrestorer.shared.listeners.event.SRServerMessageEvent;
 import net.skinsrestorer.shared.log.SRChatColor;
@@ -65,6 +69,31 @@ public class SRModInit implements SRServerPlatformInit {
         plugin.registerSkinApplier(injector.getSingleton(SkinApplierMod.class), ServerPlayer.class, wrapper);
         // Log information about the platform
         logger.info(SRChatColor.GREEN + "Running on Minecraft " + SRChatColor.YELLOW + SharedConstants.getCurrentVersion().name() + SRChatColor.GREEN + ".");
+    }
+
+    @Override
+    public void initClientCompatibility() {
+        SkinShuffleSupport skinShuffleSupport = injector.getSingleton(SkinShuffleSupport.class);
+        SRModPlatform.INSTANCE.initMessageChannel(SkinShuffleHandshakePayload.TYPE, SkinShuffleHandshakePayload.STREAM_CODEC,
+                (payload, player) -> {
+                });
+        SRModPlatform.INSTANCE.initMessageChannel(SkinShuffleRefreshPlayerListEntryPayload.TYPE, SkinShuffleRefreshPlayerListEntryPayload.STREAM_CODEC,
+                (payload, player) -> {
+                });
+        SRModPlatform.INSTANCE.initMessageChannel(SkinShuffleSkinRefreshPayload.TYPE, SkinShuffleSkinRefreshPayload.STREAM_CODEC,
+                (payload, player) -> payload.toSkinProperty().ifPresentOrElse(
+                        property -> skinShuffleSupport.handleSkinRefresh(wrapper.player(player), property),
+                        () -> logger.warning("Ignoring invalid SkinShuffle skin refresh payload from %s (%s)."
+                                .formatted(player.getGameProfile().name(), player.getGameProfile().id()))
+                ));
+
+        SRModPlatform.INSTANCE.registerPlayerJoinListener(player -> {
+            if (!skinShuffleSupport.isEnabled() || !SRModPlatform.INSTANCE.canSend(player, SkinShuffleHandshakePayload.TYPE)) {
+                return;
+            }
+
+            SRModPlatform.INSTANCE.sendPluginMessage(player, SkinShuffleHandshakePayload.INSTANCE);
+        });
     }
 
     @Override

--- a/mod/common/src/main/java/net/skinsrestorer/mod/SRModPlatform.java
+++ b/mod/common/src/main/java/net/skinsrestorer/mod/SRModPlatform.java
@@ -65,10 +65,19 @@ public interface SRModPlatform {
      * bypassing Architectury's codec wrapping which adds varint length prefixes
      * incompatible with proxy plugin messages.
      */
-    <T extends CustomPacketPayload> void initMessageChannel(
+    <T extends CustomPacketPayload> void initBidirectionalMessageChannel(
             CustomPacketPayload.Type<T> type,
             StreamCodec<? super RegistryFriendlyByteBuf, T> codec,
             BiConsumer<T, ServerPlayer> receiver);
+
+    <T extends CustomPacketPayload> void initServerboundMessageChannel(
+            CustomPacketPayload.Type<T> type,
+            StreamCodec<? super RegistryFriendlyByteBuf, T> codec,
+            BiConsumer<T, ServerPlayer> receiver);
+
+    <T extends CustomPacketPayload> void initClientboundMessageChannel(
+            CustomPacketPayload.Type<T> type,
+            StreamCodec<? super RegistryFriendlyByteBuf, T> codec);
 
     boolean canSend(ServerPlayer player, CustomPacketPayload.Type<?> type);
 

--- a/mod/common/src/main/java/net/skinsrestorer/mod/SRModPlatform.java
+++ b/mod/common/src/main/java/net/skinsrestorer/mod/SRModPlatform.java
@@ -70,6 +70,8 @@ public interface SRModPlatform {
             StreamCodec<? super RegistryFriendlyByteBuf, T> codec,
             BiConsumer<T, ServerPlayer> receiver);
 
+    boolean canSend(ServerPlayer player, CustomPacketPayload.Type<?> type);
+
     /**
      * Sends a payload to a player using the platform networking API directly,
      * bypassing Architectury's codec wrapping.

--- a/mod/common/src/main/java/net/skinsrestorer/mod/SkinApplierMod.java
+++ b/mod/common/src/main/java/net/skinsrestorer/mod/SkinApplierMod.java
@@ -24,7 +24,6 @@ import com.mojang.authlib.properties.Property;
 import com.mojang.authlib.properties.PropertyMap;
 import lombok.RequiredArgsConstructor;
 import net.minecraft.core.registries.Registries;
-import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.*;
 import net.minecraft.server.level.ChunkMap;
 import net.minecraft.server.level.ServerLevel;
@@ -34,6 +33,7 @@ import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.Entity;
 import net.skinsrestorer.api.property.SkinProperty;
 import net.skinsrestorer.mod.mixin.GameProfileAccessor;
+import net.skinsrestorer.mod.skinshuffle.SkinShuffleRefreshPlayerListEntryPayload;
 import net.skinsrestorer.shared.api.SkinApplierAccess;
 import net.skinsrestorer.shared.api.event.EventBusImpl;
 import net.skinsrestorer.shared.api.event.SkinApplyEventImpl;
@@ -105,6 +105,7 @@ public class SkinApplierMod implements SkinApplierAccess<ServerPlayer> {
 
         // Refresh the players own skin
         refresh(player);
+        refreshSkinShufflePlayerEntries(player);
     }
 
     private List<ServerPlayer> getSeenByPlayers(ServerPlayer player) {
@@ -158,6 +159,25 @@ public class SkinApplierMod implements SkinApplierAccess<ServerPlayer> {
         if (settings.getProperty(ServerConfig.DISMOUNT_PASSENGERS_ON_UPDATE) && !player.getPassengers().isEmpty()) {
             player.ejectPassengers();
         }
+    }
+
+    private void refreshSkinShufflePlayerEntries(ServerPlayer player) {
+        if (!settings.getProperty(ServerConfig.SKINSHUFFLE_SUPPORT)) {
+            return;
+        }
+
+        SkinShuffleRefreshPlayerListEntryPayload payload = new SkinShuffleRefreshPlayerListEntryPayload(player.getId());
+        for (ServerPlayer otherPlayer : getSeenByPlayers(player)) {
+            sendSkinShufflePayload(otherPlayer, payload);
+        }
+    }
+
+    private void sendSkinShufflePayload(ServerPlayer player, SkinShuffleRefreshPlayerListEntryPayload payload) {
+        if (!SRModPlatform.INSTANCE.canSend(player, SkinShuffleRefreshPlayerListEntryPayload.TYPE)) {
+            return;
+        }
+
+        SRModPlatform.INSTANCE.sendPluginMessage(player, payload);
     }
 
     @SuppressWarnings("resource")

--- a/mod/common/src/main/java/net/skinsrestorer/mod/skinshuffle/SkinShuffleHandshakePayload.java
+++ b/mod/common/src/main/java/net/skinsrestorer/mod/skinshuffle/SkinShuffleHandshakePayload.java
@@ -1,0 +1,37 @@
+/*
+ * SkinsRestorer
+ * Copyright (C) 2026  SkinsRestorer Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.skinsrestorer.mod.skinshuffle;
+
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.Identifier;
+import org.jetbrains.annotations.NotNull;
+
+import static net.skinsrestorer.shared.integration.skinshuffle.SkinShuffleChannels.HANDSHAKE;
+
+public record SkinShuffleHandshakePayload() implements CustomPacketPayload {
+    public static final Type<SkinShuffleHandshakePayload> TYPE = new Type<>(Identifier.parse(HANDSHAKE));
+    public static final SkinShuffleHandshakePayload INSTANCE = new SkinShuffleHandshakePayload();
+    public static final StreamCodec<RegistryFriendlyByteBuf, SkinShuffleHandshakePayload> STREAM_CODEC = StreamCodec.unit(INSTANCE);
+
+    @Override
+    public @NotNull Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+}

--- a/mod/common/src/main/java/net/skinsrestorer/mod/skinshuffle/SkinShuffleRefreshPlayerListEntryPayload.java
+++ b/mod/common/src/main/java/net/skinsrestorer/mod/skinshuffle/SkinShuffleRefreshPlayerListEntryPayload.java
@@ -1,0 +1,39 @@
+/*
+ * SkinsRestorer
+ * Copyright (C) 2026  SkinsRestorer Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.skinsrestorer.mod.skinshuffle;
+
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.Identifier;
+import org.jetbrains.annotations.NotNull;
+
+import static net.skinsrestorer.shared.integration.skinshuffle.SkinShuffleChannels.REFRESH_PLAYER_LIST_ENTRY;
+
+public record SkinShuffleRefreshPlayerListEntryPayload(int entityId) implements CustomPacketPayload {
+    public static final Type<SkinShuffleRefreshPlayerListEntryPayload> TYPE = new Type<>(Identifier.parse(REFRESH_PLAYER_LIST_ENTRY));
+    public static final StreamCodec<RegistryFriendlyByteBuf, SkinShuffleRefreshPlayerListEntryPayload> STREAM_CODEC = StreamCodec.of(
+            (buf, payload) -> buf.writeVarInt(payload.entityId),
+            buf -> new SkinShuffleRefreshPlayerListEntryPayload(buf.readVarInt())
+    );
+
+    @Override
+    public @NotNull Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+}

--- a/mod/common/src/main/java/net/skinsrestorer/mod/skinshuffle/SkinShuffleSkinRefreshPayload.java
+++ b/mod/common/src/main/java/net/skinsrestorer/mod/skinshuffle/SkinShuffleSkinRefreshPayload.java
@@ -1,0 +1,60 @@
+/*
+ * SkinsRestorer
+ * Copyright (C) 2026  SkinsRestorer Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.skinsrestorer.mod.skinshuffle;
+
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.Identifier;
+import net.skinsrestorer.api.property.SkinProperty;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+
+import static net.skinsrestorer.shared.integration.skinshuffle.SkinShuffleChannels.SKIN_REFRESH;
+
+public record SkinShuffleSkinRefreshPayload(String propertyName, String value, @Nullable String signature) implements CustomPacketPayload {
+    public static final Type<SkinShuffleSkinRefreshPayload> TYPE = new Type<>(Identifier.parse(SKIN_REFRESH));
+    public static final StreamCodec<RegistryFriendlyByteBuf, SkinShuffleSkinRefreshPayload> STREAM_CODEC = StreamCodec.of(
+            (buf, payload) -> {
+                buf.writeBoolean(payload.signature != null);
+                buf.writeUtf(payload.propertyName);
+                buf.writeUtf(payload.value);
+                if (payload.signature != null) {
+                    buf.writeUtf(payload.signature);
+                }
+            },
+            buf -> {
+                boolean hasSignature = buf.readBoolean();
+                String propertyName = buf.readUtf();
+                String value = buf.readUtf();
+                String signature = hasSignature ? buf.readUtf() : null;
+                return new SkinShuffleSkinRefreshPayload(propertyName, value, signature);
+            }
+    );
+
+    public Optional<SkinProperty> toSkinProperty() {
+        return SkinProperty.tryParse(propertyName, value, signature);
+    }
+
+    @Override
+    public @NotNull Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+}

--- a/mod/fabric/src/main/java/net/skinsrestorer/mod/fabric/SRModPlatformImpl.java
+++ b/mod/fabric/src/main/java/net/skinsrestorer/mod/fabric/SRModPlatformImpl.java
@@ -126,14 +126,29 @@ public class SRModPlatformImpl implements SRModPlatform {
     }
 
     @Override
-    public <T extends CustomPacketPayload> void initMessageChannel(
+    public <T extends CustomPacketPayload> void initBidirectionalMessageChannel(
+            CustomPacketPayload.Type<T> type,
+            StreamCodec<? super RegistryFriendlyByteBuf, T> codec,
+            BiConsumer<T, ServerPlayer> receiver) {
+        initServerboundMessageChannel(type, codec, receiver);
+        initClientboundMessageChannel(type, codec);
+    }
+
+    @Override
+    public <T extends CustomPacketPayload> void initServerboundMessageChannel(
             CustomPacketPayload.Type<T> type,
             StreamCodec<? super RegistryFriendlyByteBuf, T> codec,
             BiConsumer<T, ServerPlayer> receiver) {
         PayloadTypeRegistry.serverboundPlay().register(type, codec);
-        PayloadTypeRegistry.clientboundPlay().register(type, codec);
         ServerPlayNetworking.registerGlobalReceiver(type, (payload, context) ->
                 receiver.accept(payload, context.player()));
+    }
+
+    @Override
+    public <T extends CustomPacketPayload> void initClientboundMessageChannel(
+            CustomPacketPayload.Type<T> type,
+            StreamCodec<? super RegistryFriendlyByteBuf, T> codec) {
+        PayloadTypeRegistry.clientboundPlay().register(type, codec);
     }
 
     @Override

--- a/mod/fabric/src/main/java/net/skinsrestorer/mod/fabric/SRModPlatformImpl.java
+++ b/mod/fabric/src/main/java/net/skinsrestorer/mod/fabric/SRModPlatformImpl.java
@@ -137,6 +137,11 @@ public class SRModPlatformImpl implements SRModPlatform {
     }
 
     @Override
+    public boolean canSend(ServerPlayer player, CustomPacketPayload.Type<?> type) {
+        return ServerPlayNetworking.canSend(player, type);
+    }
+
+    @Override
     public void sendPluginMessage(ServerPlayer player, CustomPacketPayload payload) {
         ServerPlayNetworking.send(player, payload);
     }

--- a/mod/neoforge/src/main/java/net/skinsrestorer/mod/neoforge/SRModPlatformImpl.java
+++ b/mod/neoforge/src/main/java/net/skinsrestorer/mod/neoforge/SRModPlatformImpl.java
@@ -18,7 +18,6 @@
 package net.skinsrestorer.mod.neoforge;
 
 import net.minecraft.commands.CommandSourceStack;
-import net.minecraft.network.ConnectionProtocol;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.StreamCodec;
@@ -33,7 +32,6 @@ import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.network.PacketDistributor;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
-import net.neoforged.neoforge.network.registration.NetworkRegistry;
 import net.neoforged.neoforge.network.registration.PayloadRegistrar;
 import net.neoforged.neoforge.server.permission.PermissionAPI;
 import net.neoforged.neoforge.server.permission.events.PermissionGatherEvent;
@@ -146,18 +144,19 @@ public class SRModPlatformImpl implements SRModPlatform {
             CustomPacketPayload.Type<T> type,
             StreamCodec<? super RegistryFriendlyByteBuf, T> codec,
             BiConsumer<T, ServerPlayer> receiver) {
-        ModLoadingContext.get().getActiveContainer().getEventBus()
-                .addListener(RegisterPayloadHandlersEvent.class, event -> {
-                    PayloadRegistrar registrar = event.registrar("1").optional();
-                    registrar.playToServer(type, codec, (payload, context) ->
-                            receiver.accept(payload, (ServerPlayer) context.player()));
-                    registrar.playToClient(type, codec);
-                });
+        var container = Objects.requireNonNull(ModLoadingContext.get().getActiveContainer(), "Active NeoForge mod container");
+        var eventBus = Objects.requireNonNull(container.getEventBus(), "Active NeoForge mod event bus");
+        eventBus.addListener(RegisterPayloadHandlersEvent.class, event -> {
+            PayloadRegistrar registrar = event.registrar("1").optional();
+            registrar.playToServer(type, codec, (payload, context) ->
+                    receiver.accept(payload, (ServerPlayer) context.player()));
+            registrar.playToClient(type, codec);
+        });
     }
 
     @Override
     public boolean canSend(ServerPlayer player, CustomPacketPayload.Type<?> type) {
-        return NetworkRegistry.hasChannel(player.connection, ConnectionProtocol.PLAY, type.id());
+        return player.connection.hasChannel(type.id());
     }
 
     @Override

--- a/mod/neoforge/src/main/java/net/skinsrestorer/mod/neoforge/SRModPlatformImpl.java
+++ b/mod/neoforge/src/main/java/net/skinsrestorer/mod/neoforge/SRModPlatformImpl.java
@@ -140,17 +140,36 @@ public class SRModPlatformImpl implements SRModPlatform {
     }
 
     @Override
-    public <T extends CustomPacketPayload> void initMessageChannel(
+    public <T extends CustomPacketPayload> void initBidirectionalMessageChannel(
             CustomPacketPayload.Type<T> type,
             StreamCodec<? super RegistryFriendlyByteBuf, T> codec,
             BiConsumer<T, ServerPlayer> receiver) {
+        registerPayload(registrar -> registrar.playBidirectional(type, codec, (payload, context) ->
+                receiver.accept(payload, (ServerPlayer) context.player())));
+    }
+
+    @Override
+    public <T extends CustomPacketPayload> void initServerboundMessageChannel(
+            CustomPacketPayload.Type<T> type,
+            StreamCodec<? super RegistryFriendlyByteBuf, T> codec,
+            BiConsumer<T, ServerPlayer> receiver) {
+        registerPayload(registrar -> registrar.playToServer(type, codec, (payload, context) ->
+                receiver.accept(payload, (ServerPlayer) context.player())));
+    }
+
+    @Override
+    public <T extends CustomPacketPayload> void initClientboundMessageChannel(
+            CustomPacketPayload.Type<T> type,
+            StreamCodec<? super RegistryFriendlyByteBuf, T> codec) {
+        registerPayload(registrar -> registrar.playToClient(type, codec));
+    }
+
+    private void registerPayload(Consumer<PayloadRegistrar> registration) {
         var container = Objects.requireNonNull(ModLoadingContext.get().getActiveContainer(), "Active NeoForge mod container");
         var eventBus = Objects.requireNonNull(container.getEventBus(), "Active NeoForge mod event bus");
         eventBus.addListener(RegisterPayloadHandlersEvent.class, event -> {
             PayloadRegistrar registrar = event.registrar("1").optional();
-            registrar.playToServer(type, codec, (payload, context) ->
-                    receiver.accept(payload, (ServerPlayer) context.player()));
-            registrar.playToClient(type, codec);
+            registration.accept(registrar);
         });
     }
 

--- a/mod/neoforge/src/main/java/net/skinsrestorer/mod/neoforge/SRModPlatformImpl.java
+++ b/mod/neoforge/src/main/java/net/skinsrestorer/mod/neoforge/SRModPlatformImpl.java
@@ -18,6 +18,7 @@
 package net.skinsrestorer.mod.neoforge;
 
 import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.network.ConnectionProtocol;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.StreamCodec;
@@ -32,6 +33,7 @@ import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.network.PacketDistributor;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
+import net.neoforged.neoforge.network.registration.NetworkRegistry;
 import net.neoforged.neoforge.network.registration.PayloadRegistrar;
 import net.neoforged.neoforge.server.permission.PermissionAPI;
 import net.neoforged.neoforge.server.permission.events.PermissionGatherEvent;
@@ -151,6 +153,11 @@ public class SRModPlatformImpl implements SRModPlatform {
                             receiver.accept(payload, (ServerPlayer) context.player()));
                     registrar.playToClient(type, codec);
                 });
+    }
+
+    @Override
+    public boolean canSend(ServerPlayer player, CustomPacketPayload.Type<?> type) {
+        return NetworkRegistry.hasChannel(player.connection, ConnectionProtocol.PLAY, type.id());
     }
 
     @Override

--- a/shared/src/main/java/net/skinsrestorer/shared/config/ServerConfig.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/config/ServerConfig.java
@@ -62,6 +62,12 @@ public class ServerConfig implements SettingsHolder {
             "Proxy mode API will make server-side plugin calls to SkinsRestorer API possible. Only works if a database is set up instead of file storage.",
     })
     public static final Property<Boolean> PROXY_MODE_API = newProperty("server.proxyMode.api", true);
+    @Comment({
+            "Enables compatibility with the SkinShuffle mod.",
+            "When enabled, SkinShuffle clients can hot-swap skins through SkinsRestorer without reconnecting.",
+            "On proxy setups, install SkinsRestorer on both the proxy and backend servers for full support."
+    })
+    public static final Property<Boolean> SKINSHUFFLE_SUPPORT = newProperty("server.skinShuffleSupport", true);
 
     @Override
     public void registerComments(CommentsConfiguration conf) {

--- a/shared/src/main/java/net/skinsrestorer/shared/integration/skinshuffle/SkinShuffleChannels.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/integration/skinshuffle/SkinShuffleChannels.java
@@ -15,18 +15,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-package net.skinsrestorer.shared.plugin;
+package net.skinsrestorer.shared.integration.skinshuffle;
 
-public non-sealed interface SRServerPlatformInit extends SRPlatformInit {
-    default void initClientCompatibility() {
+public final class SkinShuffleChannels {
+    public static final String HANDSHAKE = "skinshuffle:handshake";
+    public static final String SKIN_REFRESH = "skinshuffle:skin_refresh";
+    public static final String REFRESH_PLAYER_LIST_ENTRY = "skinshuffle:refresh_player_list_entry";
+
+    private SkinShuffleChannels() {
     }
-
-    default void initMetricsJoinListener() {
-    }
-
-    void initPermissions();
-
-    void initGUIListener();
-
-    void initMessageChannel();
 }

--- a/shared/src/main/java/net/skinsrestorer/shared/integration/skinshuffle/SkinShuffleSupport.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/integration/skinshuffle/SkinShuffleSupport.java
@@ -1,0 +1,90 @@
+/*
+ * SkinsRestorer
+ * Copyright (C) 2026  SkinsRestorer Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.skinsrestorer.shared.integration.skinshuffle;
+
+import ch.jalu.configme.SettingsManager;
+import ch.jalu.injector.Injector;
+import lombok.RequiredArgsConstructor;
+import net.skinsrestorer.api.property.SkinIdentifier;
+import net.skinsrestorer.api.property.SkinProperty;
+import net.skinsrestorer.api.storage.PlayerStorage;
+import net.skinsrestorer.api.storage.SkinStorage;
+import net.skinsrestorer.shared.api.SharedSkinApplier;
+import net.skinsrestorer.shared.config.ServerConfig;
+import net.skinsrestorer.shared.log.SRLogger;
+import net.skinsrestorer.shared.subjects.SRPlayer;
+import net.skinsrestorer.shared.subjects.messages.Message;
+import net.skinsrestorer.shared.subjects.permissions.PermissionRegistry;
+
+import javax.inject.Inject;
+import java.util.Optional;
+import java.util.UUID;
+
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class SkinShuffleSupport {
+    private static final String CUSTOM_SKIN_PREFIX = "skinshuffle-";
+    private final SettingsManager settings;
+    private final Injector injector;
+    private final SkinStorage skinStorage;
+    private final PlayerStorage playerStorage;
+    private final SRLogger logger;
+
+    public boolean isEnabled() {
+        return settings.getProperty(ServerConfig.SKINSHUFFLE_SUPPORT);
+    }
+
+    public void handleSkinRefresh(SRPlayer player, byte[] data) {
+        if (!isEnabled()) {
+            return;
+        }
+
+        Optional<SkinProperty> property = SkinShuffleWire.decodeSkinRefreshPayload(data);
+        if (property.isEmpty()) {
+            logger.warning("Ignoring invalid SkinShuffle skin refresh payload from %s (%s)."
+                    .formatted(player.getName(), player.getUniqueId()));
+            return;
+        }
+
+        handleSkinRefresh(player, property.get());
+    }
+
+    public void handleSkinRefresh(SRPlayer player, SkinProperty property) {
+        if (!isEnabled()) {
+            return;
+        }
+
+        if (!player.hasPermission(PermissionRegistry.SKIN_SET)) {
+            player.sendMessage(Message.PLAYER_HAS_NO_PERMISSION_SKIN);
+            return;
+        }
+
+        String skinId = getSkinIdentifier(player.getUniqueId());
+        skinStorage.setCustomSkinData(skinId, property);
+        playerStorage.setSkinIdOfPlayer(player.getUniqueId(), SkinIdentifier.ofCustom(skinId));
+        getSkinApplier().applySkin(player.getAs(Object.class), property);
+    }
+
+    public String getSkinIdentifier(UUID playerUniqueId) {
+        return CUSTOM_SKIN_PREFIX + playerUniqueId.toString().toLowerCase();
+    }
+
+    @SuppressWarnings("unchecked")
+    private SharedSkinApplier<Object> getSkinApplier() {
+        return injector.getSingleton(SharedSkinApplier.class);
+    }
+}

--- a/shared/src/main/java/net/skinsrestorer/shared/integration/skinshuffle/SkinShuffleSupport.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/integration/skinshuffle/SkinShuffleSupport.java
@@ -27,6 +27,7 @@ import net.skinsrestorer.api.storage.SkinStorage;
 import net.skinsrestorer.shared.api.SharedSkinApplier;
 import net.skinsrestorer.shared.config.ServerConfig;
 import net.skinsrestorer.shared.log.SRLogger;
+import net.skinsrestorer.shared.plugin.SRPlatformAdapter;
 import net.skinsrestorer.shared.subjects.SRPlayer;
 import net.skinsrestorer.shared.subjects.messages.Message;
 import net.skinsrestorer.shared.subjects.permissions.PermissionRegistry;
@@ -42,6 +43,7 @@ public class SkinShuffleSupport {
     private final Injector injector;
     private final SkinStorage skinStorage;
     private final PlayerStorage playerStorage;
+    private final SRPlatformAdapter adapter;
     private final SRLogger logger;
 
     public boolean isEnabled() {
@@ -73,10 +75,14 @@ public class SkinShuffleSupport {
             return;
         }
 
-        String skinId = getSkinIdentifier(player.getUniqueId());
-        skinStorage.setCustomSkinData(skinId, property);
-        playerStorage.setSkinIdOfPlayer(player.getUniqueId(), SkinIdentifier.ofCustom(skinId));
-        getSkinApplier().applySkin(player.getAs(Object.class), property);
+        UUID playerUniqueId = player.getUniqueId();
+        Object platformPlayer = player.getAs(Object.class);
+        adapter.runAsync(() -> {
+            String skinId = getSkinIdentifier(playerUniqueId);
+            skinStorage.setCustomSkinData(skinId, property);
+            playerStorage.setSkinIdOfPlayer(playerUniqueId, SkinIdentifier.ofCustom(skinId));
+            getSkinApplier().applySkin(platformPlayer, property);
+        });
     }
 
     public String getSkinIdentifier(UUID playerUniqueId) {

--- a/shared/src/main/java/net/skinsrestorer/shared/integration/skinshuffle/SkinShuffleWire.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/integration/skinshuffle/SkinShuffleWire.java
@@ -1,0 +1,143 @@
+/*
+ * SkinsRestorer
+ * Copyright (C) 2026  SkinsRestorer Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.skinsrestorer.shared.integration.skinshuffle;
+
+import net.skinsrestorer.api.property.SkinProperty;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+public final class SkinShuffleWire {
+    private SkinShuffleWire() {
+    }
+
+    public static byte[] createHandshakePayload() {
+        return new byte[0];
+    }
+
+    public static byte[] createSkinRefreshPayload(SkinProperty property) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(1);
+        writeString(out, SkinProperty.TEXTURES_NAME);
+        writeString(out, property.getValue());
+        writeString(out, property.getSignature());
+        return out.toByteArray();
+    }
+
+    public static Optional<SkinProperty> decodeSkinRefreshPayload(byte[] data) {
+        try {
+            ByteArrayInputStream in = new ByteArrayInputStream(data);
+            boolean hasSignature = readBoolean(in);
+            String name = readString(in);
+            String value = readString(in);
+            String signature = hasSignature ? readString(in) : null;
+            if (in.available() != 0) {
+                return Optional.empty();
+            }
+
+            return SkinProperty.tryParse(name, value, signature);
+        } catch (IllegalArgumentException ex) {
+            return Optional.empty();
+        }
+    }
+
+    public static byte[] createRefreshPlayerListEntryPayload(int entityId) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        writeVarInt(out, entityId);
+        return out.toByteArray();
+    }
+
+    public static Optional<Integer> decodeRefreshPlayerListEntryPayload(byte[] data) {
+        try {
+            ByteArrayInputStream in = new ByteArrayInputStream(data);
+            int entityId = readVarInt(in);
+            if (in.available() != 0) {
+                return Optional.empty();
+            }
+
+            return Optional.of(entityId);
+        } catch (IllegalArgumentException ex) {
+            return Optional.empty();
+        }
+    }
+
+    private static boolean readBoolean(ByteArrayInputStream in) {
+        int value = in.read();
+        if (value == -1) {
+            throw new IllegalArgumentException("Unexpected end of SkinShuffle payload");
+        }
+
+        return value != 0;
+    }
+
+    private static String readString(ByteArrayInputStream in) {
+        int length = readVarInt(in);
+        if (length < 0) {
+            throw new IllegalArgumentException("Negative SkinShuffle string length");
+        }
+        if (in.available() < length) {
+            throw new IllegalArgumentException("Truncated SkinShuffle string payload");
+        }
+
+        byte[] bytes = new byte[length];
+        int read = in.read(bytes, 0, length);
+        if (read != length) {
+            throw new IllegalArgumentException("Truncated SkinShuffle string payload");
+        }
+
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+
+    private static void writeString(ByteArrayOutputStream out, String value) {
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        writeVarInt(out, bytes.length);
+        out.writeBytes(bytes);
+    }
+
+    private static int readVarInt(ByteArrayInputStream in) {
+        int value = 0;
+        int position = 0;
+
+        while (position < 5) {
+            int currentByte = in.read();
+            if (currentByte == -1) {
+                throw new IllegalArgumentException("Unexpected end of SkinShuffle varint");
+            }
+
+            value |= (currentByte & 0x7F) << (position * 7);
+            if ((currentByte & 0x80) == 0) {
+                return value;
+            }
+
+            position++;
+        }
+
+        throw new IllegalArgumentException("SkinShuffle varint is too large");
+    }
+
+    private static void writeVarInt(ByteArrayOutputStream out, int value) {
+        int current = value;
+        while ((current & ~0x7F) != 0) {
+            out.write((current & 0x7F) | 0x80);
+            current >>>= 7;
+        }
+        out.write(current);
+    }
+}

--- a/shared/src/main/java/net/skinsrestorer/shared/integration/skinshuffle/SkinShuffleWire.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/integration/skinshuffle/SkinShuffleWire.java
@@ -120,6 +120,9 @@ public final class SkinShuffleWire {
             if (currentByte == -1) {
                 throw new IllegalArgumentException("Unexpected end of SkinShuffle varint");
             }
+            if (position == 4 && (currentByte & 0xF0) != 0) {
+                throw new IllegalArgumentException("SkinShuffle varint is too large");
+            }
 
             value |= (currentByte & 0x7F) << (position * 7);
             if ((currentByte & 0x80) == 0) {

--- a/shared/src/main/java/net/skinsrestorer/shared/plugin/SRServerPlatformInit.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/plugin/SRServerPlatformInit.java
@@ -18,7 +18,7 @@
 package net.skinsrestorer.shared.plugin;
 
 public non-sealed interface SRServerPlatformInit extends SRPlatformInit {
-    default void initClientCompatibility() {
+    default void initClientCompatibility(boolean proxyMode) {
     }
 
     default void initMetricsJoinListener() {

--- a/shared/src/main/java/net/skinsrestorer/shared/plugin/SRServerPlugin.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/plugin/SRServerPlugin.java
@@ -87,6 +87,7 @@ public class SRServerPlugin {
 
     public void startupPlatform(SRServerPlatformInit init) throws InitializeException {
         init.initMetricsJoinListener();
+        init.initClientCompatibility();
 
         init.initPermissions();
 

--- a/shared/src/main/java/net/skinsrestorer/shared/plugin/SRServerPlugin.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/plugin/SRServerPlugin.java
@@ -87,7 +87,7 @@ public class SRServerPlugin {
 
     public void startupPlatform(SRServerPlatformInit init) throws InitializeException {
         init.initMetricsJoinListener();
-        init.initClientCompatibility();
+        init.initClientCompatibility(proxyMode);
 
         init.initPermissions();
 

--- a/test/src/test/java/net/skinsrestorer/skinshuffle/SkinShuffleSupportTest.java
+++ b/test/src/test/java/net/skinsrestorer/skinshuffle/SkinShuffleSupportTest.java
@@ -1,0 +1,106 @@
+/*
+ * SkinsRestorer
+ * Copyright (C) 2026  SkinsRestorer Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.skinsrestorer.skinshuffle;
+
+import ch.jalu.configme.SettingsManager;
+import ch.jalu.injector.Injector;
+import net.skinsrestorer.api.property.SkinIdentifier;
+import net.skinsrestorer.api.property.SkinProperty;
+import net.skinsrestorer.api.storage.PlayerStorage;
+import net.skinsrestorer.api.storage.SkinStorage;
+import net.skinsrestorer.shared.api.SharedSkinApplier;
+import net.skinsrestorer.shared.config.ServerConfig;
+import net.skinsrestorer.shared.integration.skinshuffle.SkinShuffleSupport;
+import net.skinsrestorer.shared.log.SRLogger;
+import net.skinsrestorer.shared.subjects.SRPlayer;
+import net.skinsrestorer.shared.subjects.permissions.PermissionRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SkinShuffleSupportTest {
+    @Mock
+    private SettingsManager settings;
+    @Mock
+    private Injector injector;
+    @Mock
+    private SkinStorage skinStorage;
+    @Mock
+    private PlayerStorage playerStorage;
+    @Mock
+    private SRLogger logger;
+    @Mock
+    private SharedSkinApplier<Object> skinApplier;
+    @Mock
+    private SRPlayer player;
+
+    @Test
+    void shouldPersistAndApplySkinRefresh() {
+        SkinShuffleSupport support = new SkinShuffleSupport(settings, injector, skinStorage, playerStorage, logger);
+        UUID uniqueId = UUID.fromString("11111111-2222-3333-4444-555555555555");
+        Object platformPlayer = new Object();
+        SkinProperty property = SkinProperty.of("value", "signature");
+        String expectedSkinId = "skinshuffle-11111111-2222-3333-4444-555555555555";
+
+        when(settings.getProperty(ServerConfig.SKINSHUFFLE_SUPPORT)).thenReturn(true);
+        when(player.hasPermission(PermissionRegistry.SKIN_SET)).thenReturn(true);
+        when(player.getUniqueId()).thenReturn(uniqueId);
+        when(player.getAs(Object.class)).thenReturn(platformPlayer);
+        when(injector.getSingleton(SharedSkinApplier.class)).thenReturn(skinApplier);
+
+        support.handleSkinRefresh(player, property);
+
+        verify(skinStorage).setCustomSkinData(expectedSkinId, property);
+        verify(playerStorage).setSkinIdOfPlayer(uniqueId, SkinIdentifier.ofCustom(expectedSkinId));
+        verify(skinApplier).applySkin(platformPlayer, property);
+    }
+
+    @Test
+    void shouldRejectSkinRefreshWithoutPermission() {
+        SkinShuffleSupport support = new SkinShuffleSupport(settings, injector, skinStorage, playerStorage, logger);
+        SkinProperty property = SkinProperty.of("value", "signature");
+
+        when(settings.getProperty(ServerConfig.SKINSHUFFLE_SUPPORT)).thenReturn(true);
+        when(player.hasPermission(PermissionRegistry.SKIN_SET)).thenReturn(false);
+
+        support.handleSkinRefresh(player, property);
+
+        verifyNoInteractions(skinStorage, playerStorage, injector);
+    }
+
+    @Test
+    void shouldIgnoreInvalidWirePayload() {
+        SkinShuffleSupport support = new SkinShuffleSupport(settings, injector, skinStorage, playerStorage, logger);
+
+        when(settings.getProperty(ServerConfig.SKINSHUFFLE_SUPPORT)).thenReturn(true);
+        when(player.getName()).thenReturn("TestPlayer");
+        when(player.getUniqueId()).thenReturn(UUID.fromString("11111111-2222-3333-4444-555555555555"));
+
+        support.handleSkinRefresh(player, new byte[]{1, 0});
+
+        verify(logger).warning(contains("Ignoring invalid SkinShuffle skin refresh payload"));
+        verifyNoInteractions(skinStorage, playerStorage, injector);
+    }
+}

--- a/test/src/test/java/net/skinsrestorer/skinshuffle/SkinShuffleSupportTest.java
+++ b/test/src/test/java/net/skinsrestorer/skinshuffle/SkinShuffleSupportTest.java
@@ -27,10 +27,12 @@ import net.skinsrestorer.shared.api.SharedSkinApplier;
 import net.skinsrestorer.shared.config.ServerConfig;
 import net.skinsrestorer.shared.integration.skinshuffle.SkinShuffleSupport;
 import net.skinsrestorer.shared.log.SRLogger;
+import net.skinsrestorer.shared.plugin.SRPlatformAdapter;
 import net.skinsrestorer.shared.subjects.SRPlayer;
 import net.skinsrestorer.shared.subjects.permissions.PermissionRegistry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -50,6 +52,8 @@ class SkinShuffleSupportTest {
     @Mock
     private PlayerStorage playerStorage;
     @Mock
+    private SRPlatformAdapter adapter;
+    @Mock
     private SRLogger logger;
     @Mock
     private SharedSkinApplier<Object> skinApplier;
@@ -58,7 +62,7 @@ class SkinShuffleSupportTest {
 
     @Test
     void shouldPersistAndApplySkinRefresh() {
-        SkinShuffleSupport support = new SkinShuffleSupport(settings, injector, skinStorage, playerStorage, logger);
+        SkinShuffleSupport support = new SkinShuffleSupport(settings, injector, skinStorage, playerStorage, adapter, logger);
         UUID uniqueId = UUID.fromString("11111111-2222-3333-4444-555555555555");
         Object platformPlayer = new Object();
         SkinProperty property = SkinProperty.of("value", "signature");
@@ -72,6 +76,12 @@ class SkinShuffleSupportTest {
 
         support.handleSkinRefresh(player, property);
 
+        ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(adapter).runAsync(taskCaptor.capture());
+        verifyNoInteractions(skinStorage, playerStorage, skinApplier);
+
+        taskCaptor.getValue().run();
+
         verify(skinStorage).setCustomSkinData(expectedSkinId, property);
         verify(playerStorage).setSkinIdOfPlayer(uniqueId, SkinIdentifier.ofCustom(expectedSkinId));
         verify(skinApplier).applySkin(platformPlayer, property);
@@ -79,7 +89,7 @@ class SkinShuffleSupportTest {
 
     @Test
     void shouldRejectSkinRefreshWithoutPermission() {
-        SkinShuffleSupport support = new SkinShuffleSupport(settings, injector, skinStorage, playerStorage, logger);
+        SkinShuffleSupport support = new SkinShuffleSupport(settings, injector, skinStorage, playerStorage, adapter, logger);
         SkinProperty property = SkinProperty.of("value", "signature");
 
         when(settings.getProperty(ServerConfig.SKINSHUFFLE_SUPPORT)).thenReturn(true);
@@ -87,12 +97,12 @@ class SkinShuffleSupportTest {
 
         support.handleSkinRefresh(player, property);
 
-        verifyNoInteractions(skinStorage, playerStorage, injector);
+        verifyNoInteractions(skinStorage, playerStorage, injector, adapter);
     }
 
     @Test
     void shouldIgnoreInvalidWirePayload() {
-        SkinShuffleSupport support = new SkinShuffleSupport(settings, injector, skinStorage, playerStorage, logger);
+        SkinShuffleSupport support = new SkinShuffleSupport(settings, injector, skinStorage, playerStorage, adapter, logger);
 
         when(settings.getProperty(ServerConfig.SKINSHUFFLE_SUPPORT)).thenReturn(true);
         when(player.getName()).thenReturn("TestPlayer");
@@ -101,6 +111,6 @@ class SkinShuffleSupportTest {
         support.handleSkinRefresh(player, new byte[]{1, 0});
 
         verify(logger).warning(contains("Ignoring invalid SkinShuffle skin refresh payload"));
-        verifyNoInteractions(skinStorage, playerStorage, injector);
+        verifyNoInteractions(skinStorage, playerStorage, injector, adapter);
     }
 }

--- a/test/src/test/java/net/skinsrestorer/skinshuffle/SkinShuffleWireTest.java
+++ b/test/src/test/java/net/skinsrestorer/skinshuffle/SkinShuffleWireTest.java
@@ -51,4 +51,11 @@ class SkinShuffleWireTest {
         assertArrayEquals(new byte[]{(byte) 0xAC, 0x02}, encoded);
         assertEquals(300, SkinShuffleWire.decodeRefreshPlayerListEntryPayload(encoded).orElseThrow());
     }
+
+    @Test
+    void shouldRejectRefreshPlayerListEntryVarIntLargerThan32Bits() {
+        byte[] encoded = {(byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80, 0x10};
+
+        assertTrue(SkinShuffleWire.decodeRefreshPlayerListEntryPayload(encoded).isEmpty());
+    }
 }

--- a/test/src/test/java/net/skinsrestorer/skinshuffle/SkinShuffleWireTest.java
+++ b/test/src/test/java/net/skinsrestorer/skinshuffle/SkinShuffleWireTest.java
@@ -1,0 +1,54 @@
+/*
+ * SkinsRestorer
+ * Copyright (C) 2026  SkinsRestorer Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.skinsrestorer.skinshuffle;
+
+import net.skinsrestorer.api.property.SkinProperty;
+import net.skinsrestorer.shared.integration.skinshuffle.SkinShuffleWire;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SkinShuffleWireTest {
+    @Test
+    void shouldDecodeSkinRefreshPayloadRoundTrip() {
+        SkinProperty property = SkinProperty.of("value", "signature");
+
+        byte[] encoded = SkinShuffleWire.createSkinRefreshPayload(property);
+
+        assertEquals(property, SkinShuffleWire.decodeSkinRefreshPayload(encoded).orElseThrow());
+    }
+
+    @Test
+    void shouldRejectUnsignedSkinRefreshPayload() {
+        byte[] encoded = {
+                0,
+                8, 't', 'e', 'x', 't', 'u', 'r', 'e', 's',
+                5, 'v', 'a', 'l', 'u', 'e'
+        };
+
+        assertTrue(SkinShuffleWire.decodeSkinRefreshPayload(encoded).isEmpty());
+    }
+
+    @Test
+    void shouldEncodeRefreshPlayerListEntryAsVarInt() {
+        byte[] encoded = SkinShuffleWire.createRefreshPlayerListEntryPayload(300);
+
+        assertArrayEquals(new byte[]{(byte) 0xAC, 0x02}, encoded);
+        assertEquals(300, SkinShuffleWire.decodeRefreshPlayerListEntryPayload(encoded).orElseThrow());
+    }
+}

--- a/velocity/src/main/java/net/skinsrestorer/velocity/SRVelocityInit.java
+++ b/velocity/src/main/java/net/skinsrestorer/velocity/SRVelocityInit.java
@@ -24,6 +24,7 @@ import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
 import lombok.RequiredArgsConstructor;
 import net.skinsrestorer.miniplaceholders.SRMiniPlaceholdersAPIExpansion;
+import net.skinsrestorer.shared.integration.skinshuffle.SkinShuffleChannels;
 import net.skinsrestorer.shared.log.SRLogger;
 import net.skinsrestorer.shared.plugin.SRPlugin;
 import net.skinsrestorer.shared.plugin.SRProxyPlatformInit;
@@ -32,6 +33,8 @@ import net.skinsrestorer.shared.utils.SRHelpers;
 import net.skinsrestorer.velocity.listener.AdminInfoListener;
 import net.skinsrestorer.velocity.listener.GameProfileRequest;
 import net.skinsrestorer.velocity.listener.ProxyMessageListener;
+import net.skinsrestorer.velocity.listener.SkinShuffleHandshakeListener;
+import net.skinsrestorer.velocity.listener.SkinShuffleProxyMessageListener;
 import net.skinsrestorer.velocity.wrapper.WrapperVelocity;
 
 import javax.inject.Inject;
@@ -60,6 +63,7 @@ public class SRVelocityInit implements SRProxyPlatformInit {
     @Override
     public void initAdminInfoListener() {
         proxy.getEventManager().register(adapter.pluginInstance(), injector.newInstance(AdminInfoListener.class));
+        proxy.getEventManager().register(adapter.pluginInstance(), injector.newInstance(SkinShuffleHandshakeListener.class));
     }
 
     @Override
@@ -70,7 +74,11 @@ public class SRVelocityInit implements SRProxyPlatformInit {
     @Override
     public void initMessageChannel() {
         proxy.getChannelRegistrar().register(MinecraftChannelIdentifier.from(SRHelpers.MESSAGE_CHANNEL));
+        proxy.getChannelRegistrar().register(MinecraftChannelIdentifier.from(SkinShuffleChannels.SKIN_REFRESH));
+        proxy.getChannelRegistrar().register(MinecraftChannelIdentifier.from(SkinShuffleChannels.HANDSHAKE));
+        proxy.getChannelRegistrar().register(MinecraftChannelIdentifier.from(SkinShuffleChannels.REFRESH_PLAYER_LIST_ENTRY));
         proxy.getEventManager().register(adapter.pluginInstance(), PluginMessageEvent.class, injector.getSingleton(ProxyMessageListener.class));
+        proxy.getEventManager().register(adapter.pluginInstance(), PluginMessageEvent.class, injector.getSingleton(SkinShuffleProxyMessageListener.class));
     }
 
     @Override

--- a/velocity/src/main/java/net/skinsrestorer/velocity/listener/SkinShuffleHandshakeListener.java
+++ b/velocity/src/main/java/net/skinsrestorer/velocity/listener/SkinShuffleHandshakeListener.java
@@ -1,0 +1,45 @@
+/*
+ * SkinsRestorer
+ * Copyright (C) 2026  SkinsRestorer Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.skinsrestorer.velocity.listener;
+
+import ch.jalu.configme.SettingsManager;
+import com.velocitypowered.api.event.PostOrder;
+import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.player.ServerConnectedEvent;
+import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
+import lombok.RequiredArgsConstructor;
+import net.skinsrestorer.shared.config.ServerConfig;
+import net.skinsrestorer.shared.integration.skinshuffle.SkinShuffleChannels;
+import net.skinsrestorer.shared.integration.skinshuffle.SkinShuffleWire;
+
+import javax.inject.Inject;
+
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class SkinShuffleHandshakeListener {
+    private static final MinecraftChannelIdentifier HANDSHAKE_CHANNEL = MinecraftChannelIdentifier.from(SkinShuffleChannels.HANDSHAKE);
+    private final SettingsManager settings;
+
+    @Subscribe(order = PostOrder.LAST)
+    public void onServerConnected(ServerConnectedEvent event) {
+        if (!settings.getProperty(ServerConfig.SKINSHUFFLE_SUPPORT)) {
+            return;
+        }
+
+        event.getPlayer().sendPluginMessage(HANDSHAKE_CHANNEL, SkinShuffleWire.createHandshakePayload());
+    }
+}

--- a/velocity/src/main/java/net/skinsrestorer/velocity/listener/SkinShuffleProxyMessageListener.java
+++ b/velocity/src/main/java/net/skinsrestorer/velocity/listener/SkinShuffleProxyMessageListener.java
@@ -1,0 +1,51 @@
+/*
+ * SkinsRestorer
+ * Copyright (C) 2026  SkinsRestorer Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.skinsrestorer.velocity.listener;
+
+import com.velocitypowered.api.event.EventHandler;
+import com.velocitypowered.api.event.connection.PluginMessageEvent;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ServerConnection;
+import lombok.RequiredArgsConstructor;
+import net.skinsrestorer.shared.integration.skinshuffle.SkinShuffleChannels;
+import net.skinsrestorer.shared.integration.skinshuffle.SkinShuffleSupport;
+import net.skinsrestorer.velocity.wrapper.WrapperVelocity;
+
+import javax.inject.Inject;
+
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class SkinShuffleProxyMessageListener implements EventHandler<PluginMessageEvent> {
+    private final WrapperVelocity wrapper;
+    private final SkinShuffleSupport skinShuffleSupport;
+
+    @Override
+    public void execute(PluginMessageEvent event) {
+        if (!SkinShuffleChannels.SKIN_REFRESH.equals(event.getIdentifier().getId())) {
+            return;
+        }
+        if (!(event.getSource() instanceof Player player) || !(event.getTarget() instanceof ServerConnection)) {
+            return;
+        }
+        if (!skinShuffleSupport.isEnabled()) {
+            return;
+        }
+
+        event.setResult(PluginMessageEvent.ForwardResult.handled());
+        skinShuffleSupport.handleSkinRefresh(wrapper.player(player), event.getData());
+    }
+}


### PR DESCRIPTION
## What changed

This adds a full SkinShuffle bridge to SkinsRestorer with a shared config toggle at `server.skinShuffleSupport` that defaults to enabled.

The integration now:
- accepts `skinshuffle:skin_refresh` updates and applies them through SkinsRestorer
- persists SkinShuffle-selected skins in SkinsRestorer storage so reconnects keep the selected skin
- sends the SkinShuffle handshake to clients on supported platforms
- sends `refresh_player_list_entry` updates after a skin change so SkinShuffle clients refresh immediately
- supports Bukkit, Fabric, NeoForge, Velocity, and Bungee entry points

## Why it changed

SkinShuffle clients can already hot-swap skins when the server or plugin speaks SkinShuffle's protocol. SkinsRestorer already had the skin application and proxy forwarding pieces, but it did not understand SkinShuffle's channels or refresh flow.

This change adds the missing protocol bridge so SkinShuffle clients can use SkinsRestorer as the server-side integration point instead of requiring the SkinShuffle project itself.

## User and developer impact

Users can leave `server.skinShuffleSupport` enabled and SkinShuffle clients will hot-swap skins through SkinsRestorer across supported setups.

On proxy networks, the proxy now accepts SkinShuffle client updates and forwards them through the existing SkinsRestorer proxy-to-backend skin update path, while backend server platforms perform the final live refresh for connected clients.

## Root cause

SkinsRestorer did not register or handle SkinShuffle's custom payload channels, so SkinShuffle clients had no way to hand their signed texture property to SkinsRestorer or receive the client-side cache refresh signal they expect.

## Validation

I ran:
- `./gradlew :skinsrestorer-shared:compileJava :skinsrestorer-bukkit:compileJava :skinsrestorer-mod-common:compileJava :skinsrestorer-velocity:compileJava :skinsrestorer-bungee:compileJava :test:test --tests "net.skinsrestorer.skinshuffle.*"`
- `./gradlew spotlessCheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SkinShuffle compatibility across Bukkit, BungeeCord, Velocity, Fabric, and NeoForge.
  * Skin updates now synchronize with SkinShuffle player lists.
  * Added configurable SkinShuffle support, enabled by default.
  * Added support for Minecraft 26.3+ Paper and Spigot mappings.

* **Bug Fixes**
  * Invalid or unauthorized SkinShuffle skin-refresh requests are rejected safely.

* **Tests**
  * Added coverage for skin refresh handling and network payload validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->