### PR TITLE
feat(fand): add native Fand platform support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,5 +33,6 @@ jobs:
           name: SkinsRestorer
           path: |
             ./build/libs/SkinsRestorer.jar
+            ./build/libs/SkinsRestorer-Fand-*.jar
             ./build/libs/SkinsRestorer-Mod-Fabric-*.jar
             ./build/libs/SkinsRestorer-Mod-NeoForge-*.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,7 @@ jobs:
 
         files: |
           build/libs/SkinsRestorer.jar
+          build/libs/SkinsRestorer-Fand-*.jar
           build/libs/SkinsRestorer-Mod-Fabric-*.jar
           build/libs/SkinsRestorer-Mod-NeoForge-*.jar
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -100,6 +100,12 @@ allprojects {
             }
             mavenContent { snapshotsOnly() }
         }
+        maven("https://repo.fandmc.cn/repository/maven-public/") {
+            name = "FandMC Repository"
+            content {
+                includeGroup("io.fand")
+            }
+        }
         maven("https://central.sonatype.com/repository/maven-snapshots/") {
             name = "Sonatype Snapshot Repository"
             mavenContent { snapshotsOnly() }

--- a/fand/build.gradle.kts
+++ b/fand/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+    id("sr.shadow-logic")
+}
+
+base {
+    archivesName = "SkinsRestorer-Fand"
+}
+
+dependencies {
+    compileOnly(projects.skinsrestorerShared)
+    runtimeOnly(project(":skinsrestorer-shared", "shadow"))
+
+    compileOnly("io.fand:fand-api:${rootProject.property("fandVersion")}")
+    testImplementation("io.fand:fand-api:${rootProject.property("fandVersion")}")
+    testImplementation(testFixtures(projects.test))
+}
+
+tasks.processResources {
+    filesMatching("fand-plugin.json") {
+        expand(inputs.properties.filter {
+            it.key in setOf("version", "description")
+        }.plus("url" to "https://skinsrestorer.net"))
+    }
+}
+
+tasks.shadowJar {
+    archiveClassifier.set("")
+    destinationDirectory.set(rootProject.layout.buildDirectory.dir("libs"))
+}

--- a/fand/src/main/java/net/skinsrestorer/fand/FandLoginProfileListener.java
+++ b/fand/src/main/java/net/skinsrestorer/fand/FandLoginProfileListener.java
@@ -1,0 +1,69 @@
+/*
+ * SkinsRestorer
+ * Copyright (C) 2026  SkinsRestorer Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.skinsrestorer.fand;
+
+import io.fand.api.event.player.AsyncPlayerPreLoginEvent;
+import io.fand.api.player.PlayerSkin;
+import lombok.RequiredArgsConstructor;
+import net.skinsrestorer.api.property.SkinProperty;
+import net.skinsrestorer.shared.listeners.LoginProfileListenerAdapter;
+import net.skinsrestorer.shared.listeners.event.SRLoginProfileEvent;
+
+import javax.inject.Inject;
+import java.util.UUID;
+
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public final class FandLoginProfileListener {
+    private final LoginProfileListenerAdapter<Void> adapter;
+
+    public void login(AsyncPlayerPreLoginEvent event) {
+        adapter.handleLogin(new SRLoginProfileEvent<>() {
+            @Override
+            public boolean hasOnlineProperties() {
+                return event.profile().skin().isPresent();
+            }
+
+            @Override
+            public UUID getPlayerUniqueId() {
+                return event.uniqueId();
+            }
+
+            @Override
+            public String getPlayerName() {
+                return event.name();
+            }
+
+            @Override
+            public boolean isCancelled() {
+                return event.result() != AsyncPlayerPreLoginEvent.Result.ALLOWED;
+            }
+
+            @Override
+            public void setResultProperty(SkinProperty property) {
+                event.setProfile(event.profile().withSkin(
+                        new PlayerSkin(property.getValue(), property.getSignature())));
+            }
+
+            @Override
+            public Void runAsync(Runnable runnable) {
+                runnable.run();
+                return null;
+            }
+        });
+    }
+}

--- a/fand/src/main/java/net/skinsrestorer/fand/FandSoundProvider.java
+++ b/fand/src/main/java/net/skinsrestorer/fand/FandSoundProvider.java
@@ -1,0 +1,83 @@
+/*
+ * SkinsRestorer
+ * Copyright (C) 2026  SkinsRestorer Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.skinsrestorer.fand;
+
+import ch.jalu.configme.SettingsManager;
+import io.fand.api.entity.Player;
+import lombok.RequiredArgsConstructor;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.sound.Sound;
+import net.skinsrestorer.shared.commands.SoundProvider;
+import net.skinsrestorer.shared.config.ServerConfig;
+import net.skinsrestorer.shared.log.SRLogger;
+import net.skinsrestorer.shared.sound.SoundParser;
+import net.skinsrestorer.shared.subjects.SRPlayer;
+
+import javax.inject.Inject;
+import java.util.Locale;
+
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public final class FandSoundProvider implements SoundProvider {
+    private final SettingsManager settings;
+    private final SRLogger logger;
+
+    @Override
+    public void playSound(SRPlayer player) {
+        if (!settings.getProperty(ServerConfig.SOUND_ENABLED)) {
+            return;
+        }
+        SoundParser.Record parsed = SoundParser.parse(settings.getProperty(ServerConfig.SOUND_VALUE));
+        if (parsed == null) {
+            return;
+        }
+        try {
+            String soundName = parsed.getSound().toLowerCase(Locale.ROOT).replace('_', '.');
+            if (!soundName.contains(":")) {
+                soundName = "minecraft:" + soundName;
+            }
+            Sound effect = Sound.sound()
+                    .type(Key.key(soundName))
+                    .source(source(parsed.getCategory()))
+                    .volume(parsed.getVolume())
+                    .pitch(parsed.getPitch())
+                    .seed(parsed.generateSeed())
+                    .build();
+            player.getAs(Player.class).playSound(effect);
+        } catch (IllegalArgumentException invalidSound) {
+            logger.warning("Invalid sound value in config: %s".formatted(
+                    settings.getProperty(ServerConfig.SOUND_VALUE)), invalidSound);
+        }
+    }
+
+    private static Sound.Source source(String category) {
+        return switch (category.toUpperCase(Locale.ROOT)) {
+            case "MASTER" -> Sound.Source.MASTER;
+            case "MUSIC" -> Sound.Source.MUSIC;
+            case "RECORD", "RECORDS" -> Sound.Source.RECORD;
+            case "WEATHER" -> Sound.Source.WEATHER;
+            case "BLOCK", "BLOCKS" -> Sound.Source.BLOCK;
+            case "HOSTILE" -> Sound.Source.HOSTILE;
+            case "NEUTRAL" -> Sound.Source.NEUTRAL;
+            case "PLAYER", "PLAYERS" -> Sound.Source.PLAYER;
+            case "AMBIENT" -> Sound.Source.AMBIENT;
+            case "VOICE" -> Sound.Source.VOICE;
+            case "UI" -> Sound.Source.UI;
+            default -> throw new IllegalArgumentException("Unknown sound category: " + category);
+        };
+    }
+}

--- a/fand/src/main/java/net/skinsrestorer/fand/SRFandAdapter.java
+++ b/fand/src/main/java/net/skinsrestorer/fand/SRFandAdapter.java
@@ -1,0 +1,226 @@
+/*
+ * SkinsRestorer
+ * Copyright (C) 2026  SkinsRestorer Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.skinsrestorer.fand;
+
+import ch.jalu.injector.Injector;
+import io.fand.api.Fand;
+import io.fand.api.command.CommandSender;
+import io.fand.api.entity.Player;
+import io.fand.api.item.ItemStack;
+import io.fand.api.item.component.ItemProfile;
+import io.fand.api.network.ProxyForwardingMode;
+import io.fand.api.plugin.PluginContext;
+import lombok.RequiredArgsConstructor;
+import net.kyori.adventure.key.Key;
+import net.skinsrestorer.api.property.SkinProperty;
+import net.skinsrestorer.fand.command.FandCommandManager;
+import net.skinsrestorer.fand.gui.FandGUI;
+import net.skinsrestorer.fand.wrapper.FandComponentHelper;
+import net.skinsrestorer.fand.wrapper.WrapperFand;
+import net.skinsrestorer.shared.codec.SRServerPluginMessage;
+import net.skinsrestorer.shared.commands.SoundProvider;
+import net.skinsrestorer.shared.gui.SRInventory;
+import net.skinsrestorer.shared.info.Platform;
+import net.skinsrestorer.shared.info.PluginInfo;
+import net.skinsrestorer.shared.plugin.SRPlatformAdapter;
+import net.skinsrestorer.shared.plugin.SRServerAdapter;
+import net.skinsrestorer.shared.subjects.SRCommandSender;
+import net.skinsrestorer.shared.subjects.SRPlayer;
+import net.skinsrestorer.shared.utils.SRHelpers;
+import org.incendo.cloud.CommandManager;
+import org.incendo.cloud.SenderMapper;
+import org.incendo.cloud.execution.ExecutionCoordinator;
+
+import javax.inject.Inject;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public final class SRFandAdapter implements SRServerAdapter {
+    public static final Key MESSAGE_CHANNEL = Key.key(SRHelpers.MESSAGE_CHANNEL);
+    private static final List<Object> REFERENCES_TO_PREVENT_GC = new ArrayList<>();
+
+    private final PluginContext context;
+    private final Injector injector;
+    private final ScheduledExecutorService asyncScheduler = Executors.newSingleThreadScheduledExecutor(
+            Thread.ofPlatform().daemon().name("SkinsRestorer-Fand-Async").factory());
+
+    @Override
+    public CommandManager<SRCommandSender> createCommandManager() {
+        WrapperFand wrapper = injector.getSingleton(WrapperFand.class);
+        return new FandCommandManager<>(
+                context.commands(),
+                ExecutionCoordinator.asyncCoordinator(),
+                SenderMapper.create(wrapper::commandSender, wrapper::unwrap),
+                context.logger());
+    }
+
+    @Override
+    public Collection<SRPlayer> getOnlinePlayers(SRCommandSender sender) {
+        WrapperFand wrapper = injector.getSingleton(WrapperFand.class);
+        return Fand.server().players().stream().<SRPlayer>map(wrapper::player).toList();
+    }
+
+    @Override
+    public Optional<SRPlayer> getPlayer(SRCommandSender sender, UUID uniqueId) {
+        WrapperFand wrapper = injector.getSingleton(WrapperFand.class);
+        return Fand.server().player(uniqueId).map(wrapper::player);
+    }
+
+    @Override
+    public InputStream getResource(String resource) {
+        return SRPlatformAdapter.class.getClassLoader().getResourceAsStream(resource);
+    }
+
+    @Override
+    public void runAsync(Runnable runnable) {
+        asyncScheduler.execute(runnable);
+    }
+
+    @Override
+    public void runAsyncDelayed(Runnable runnable, long delay, TimeUnit timeUnit) {
+        asyncScheduler.schedule(runnable, delay, timeUnit);
+    }
+
+    @Override
+    public void runRepeatAsync(Runnable runnable, long delay, long interval, TimeUnit timeUnit) {
+        asyncScheduler.scheduleWithFixedDelay(runnable, delay, interval, timeUnit);
+    }
+
+    @Override
+    public void runSync(SRCommandSender sender, Runnable runnable) {
+        context.scheduler().runMain(runnable);
+    }
+
+    @Override
+    public void runSyncToPlayer(SRPlayer player, Runnable runnable) {
+        context.scheduler().runMain(runnable);
+    }
+
+    @Override
+    public boolean determineProxy() {
+        return Fand.server().proxyForwardingMode() != ProxyForwardingMode.NONE;
+    }
+
+    @Override
+    public String getPlatformVersion() {
+        return Fand.server().version();
+    }
+
+    @Override
+    public String getPlatformName() {
+        return "Fand";
+    }
+
+    @Override
+    public String getPlatformVendor() {
+        return "FandMC";
+    }
+
+    @Override
+    public Platform getPlatform() {
+        return Platform.FAND;
+    }
+
+    @Override
+    public List<PluginInfo> getPlugins() {
+        var plugins = Fand.server().plugins();
+        return plugins.loadedDescriptors().stream()
+                .map(descriptor -> new PluginInfo(
+                        plugins.isEnabled(descriptor.id()),
+                        descriptor.id(),
+                        descriptor.id(),
+                        descriptor.version(),
+                        descriptor.mainClass(),
+                        Map.of("website", descriptor.website().isBlank() ? "N/A" : descriptor.website()),
+                        descriptor.authors()))
+                .toList();
+    }
+
+    @Override
+    public Optional<SkinProperty> getSkinProperty(SRPlayer player) {
+        return player.getAs(Player.class).skin()
+                .flatMap(skin -> skin.signature().map(signature -> SkinProperty.of(skin.value(), signature)));
+    }
+
+    @Override
+    public Object createMetricsInstance() {
+        return null;
+    }
+
+    @Override
+    public void extendLifeTime(Object plugin, Object object) {
+        REFERENCES_TO_PREVENT_GC.add(object);
+    }
+
+    @Override
+    public boolean supportsDefaultPermissions() {
+        return true;
+    }
+
+    @Override
+    public void shutdownCleanup() {
+        asyncScheduler.shutdownNow();
+        REFERENCES_TO_PREVENT_GC.clear();
+    }
+
+    @Override
+    public void openGUI(SRPlayer player, SRInventory srInventory) {
+        runSyncToPlayer(player, () -> injector.getSingleton(FandGUI.class)
+                .open(player.getAs(Player.class), srInventory));
+    }
+
+    @Override
+    public void giveSkullItem(
+            SRPlayer player,
+            SRServerPluginMessage.GiveSkullChannelPayload giveSkullPayload
+    ) {
+        runSyncToPlayer(player, () -> {
+            var type = Fand.server().itemType(Key.key("minecraft:player_head"))
+                    .orElseThrow(() -> new IllegalStateException("Fand does not expose minecraft:player_head"));
+            var property = ItemProfile.Property.unsigned(
+                    SkinProperty.TEXTURES_NAME,
+                    SRHelpers.encodeHashToTexturesValue(giveSkullPayload.textureHash()));
+            ItemStack stack = new ItemStack(type, 1)
+                    .withProfile(new ItemProfile(null, null, List.of(property), null, null, null, null))
+                    .withCustomName(FandComponentHelper.deserialize(giveSkullPayload.displayName()));
+            player.getAs(Player.class).inventory().add(stack);
+        });
+    }
+
+    @Override
+    public Class<? extends SoundProvider> getSoundProviderClass() {
+        return FandSoundProvider.class;
+    }
+
+    public void sendPluginMessage(Player player, byte[] data) {
+        context.pluginMessaging().send(player, MESSAGE_CHANNEL, data);
+    }
+
+    SRPlayer getPlayerForScheduling(Player player) {
+        return injector.getSingleton(WrapperFand.class).player(player);
+    }
+}

--- a/fand/src/main/java/net/skinsrestorer/fand/SRFandBootstrap.java
+++ b/fand/src/main/java/net/skinsrestorer/fand/SRFandBootstrap.java
@@ -1,0 +1,70 @@
+/*
+ * SkinsRestorer
+ * Copyright (C) 2026  SkinsRestorer Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.skinsrestorer.fand;
+
+import io.fand.api.Fand;
+import io.fand.api.plugin.Plugin;
+import io.fand.api.plugin.PluginContext;
+import net.skinsrestorer.api.semver.SemanticVersion;
+import net.skinsrestorer.shared.plugin.SRBootstrapper;
+import net.skinsrestorer.shared.plugin.SRServerPlugin;
+
+import java.util.List;
+
+public final class SRFandBootstrap implements Plugin {
+    private static final SemanticVersion MINIMUM_FAND_VERSION = new SemanticVersion(0, 8, 2);
+
+    private Runnable shutdownHook = () -> {
+    };
+
+    @Override
+    public void onEnable(PluginContext context) {
+        requireSupportedFandVersion();
+        SRBootstrapper.startPlugin(
+                hook -> shutdownHook = hook,
+                List.of(new SRBootstrapper.PlatformClass<>(PluginContext.class, context)),
+                new SRFandLogger(context.logger()),
+                false,
+                SRFandAdapter.class,
+                SRServerPlugin.class,
+                context.dataDirectory(),
+                SRFandInit.class
+        );
+    }
+
+    private static void requireSupportedFandVersion() {
+        String version = Fand.server().version();
+        final SemanticVersion current;
+        try {
+            current = SemanticVersion.fromString(version);
+        } catch (RuntimeException invalidVersion) {
+            throw new IllegalStateException("Unable to verify Fand version: " + version, invalidVersion);
+        }
+        if (current.isOlderThan(MINIMUM_FAND_VERSION)) {
+            throw new IllegalStateException(
+                    "SkinsRestorer requires Fand 0.8.2 or newer; running " + version);
+        }
+    }
+
+    @Override
+    public void onDisable(PluginContext context) {
+        shutdownHook.run();
+        shutdownHook = () -> {
+        };
+    }
+}

--- a/fand/src/main/java/net/skinsrestorer/fand/SRFandInit.java
+++ b/fand/src/main/java/net/skinsrestorer/fand/SRFandInit.java
@@ -1,0 +1,138 @@
+/*
+ * SkinsRestorer
+ * Copyright (C) 2026  SkinsRestorer Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.skinsrestorer.fand;
+
+import ch.jalu.injector.Injector;
+import io.fand.api.entity.Player;
+import io.fand.api.event.player.AsyncPlayerPreLoginEvent;
+import io.fand.api.event.player.PlayerJoinEvent;
+import io.fand.api.messaging.PluginMessageDirection;
+import io.fand.api.permission.PermissionDefault;
+import io.fand.api.permission.PermissionDescriptor;
+import io.fand.api.plugin.PluginContext;
+import lombok.RequiredArgsConstructor;
+import net.skinsrestorer.fand.placeholder.FandPlaceholderExpansion;
+import net.skinsrestorer.fand.wrapper.WrapperFand;
+import net.skinsrestorer.shared.listeners.AdminInfoListenerAdapter;
+import net.skinsrestorer.shared.listeners.SRServerMessageAdapter;
+import net.skinsrestorer.shared.listeners.event.SRServerMessageEvent;
+import net.skinsrestorer.shared.log.SRChatColor;
+import net.skinsrestorer.shared.log.SRLogger;
+import net.skinsrestorer.shared.plugin.SRPlugin;
+import net.skinsrestorer.shared.plugin.SRServerPlatformInit;
+import net.skinsrestorer.shared.subjects.SRServerPlayer;
+import net.skinsrestorer.shared.subjects.permissions.PermissionGroup;
+import net.skinsrestorer.shared.subjects.permissions.PermissionRegistry;
+
+import javax.inject.Inject;
+import java.util.HashMap;
+import java.util.Map;
+
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public final class SRFandInit implements SRServerPlatformInit {
+    private final SRPlugin plugin;
+    private final SRFandAdapter adapter;
+    private final Injector injector;
+    private final PluginContext context;
+    private final SRLogger logger;
+    private final WrapperFand wrapper;
+
+    @Override
+    public void initSkinApplier() {
+        plugin.registerSkinApplier(injector.getSingleton(SkinApplierFand.class), Player.class, wrapper);
+        logger.info(SRChatColor.GREEN + "Running on Fand " + SRChatColor.YELLOW
+                + adapter.getPlatformVersion() + SRChatColor.GREEN + ".");
+    }
+
+    @Override
+    public void initLoginProfileListener() {
+        FandLoginProfileListener listener = injector.getSingleton(FandLoginProfileListener.class);
+        context.events().subscribe(AsyncPlayerPreLoginEvent.class, listener::login);
+    }
+
+    @Override
+    public void initAdminInfoListener() {
+        AdminInfoListenerAdapter adminInfo = injector.getSingleton(AdminInfoListenerAdapter.class);
+        context.events().subscribe(PlayerJoinEvent.class,
+                event -> adminInfo.handleConnect(() -> wrapper.player(event.player())));
+    }
+
+    @Override
+    public void initPermissions() {
+        for (PermissionRegistry permission : PermissionRegistry.values()) {
+            context.permissions().register(new PermissionDescriptor(
+                    permission.getPermission().getPermissionString(),
+                    PermissionDefault.OPERATOR));
+        }
+
+        for (PermissionGroup group : PermissionGroup.values()) {
+            Map<String, Boolean> children = new HashMap<>();
+            mergePermissions(group, children);
+            PermissionDefault defaultAccess = group == PermissionGroup.PLAYER
+                    ? PermissionDefault.TRUE
+                    : PermissionDefault.OPERATOR;
+            context.permissions().register(new PermissionDescriptor(
+                    group.getBasePermission().getPermissionString(), defaultAccess, children));
+            context.permissions().register(new PermissionDescriptor(
+                    group.getWildcard().getPermissionString(), defaultAccess, children));
+        }
+    }
+
+    private void mergePermissions(PermissionGroup group, Map<String, Boolean> children) {
+        for (PermissionRegistry permission : group.getPermissions()) {
+            children.put(permission.getPermission().getPermissionString(), true);
+        }
+        for (PermissionGroup parent : group.getParents()) {
+            mergePermissions(parent, children);
+        }
+    }
+
+    @Override
+    public void initGUIListener() {
+        // Fand's GuiService owns the inventory event lifecycle.
+    }
+
+    @Override
+    public void initMessageChannel() {
+        SRServerMessageAdapter messageAdapter = injector.getSingleton(SRServerMessageAdapter.class);
+        context.pluginMessaging().register(
+                SRFandAdapter.MESSAGE_CHANNEL,
+                PluginMessageDirection.BIDIRECTIONAL,
+                (player, channel, payload) -> messageAdapter.handlePluginMessage(new SRServerMessageEvent() {
+                    @Override
+                    public SRServerPlayer getPlayer() {
+                        return wrapper.player(player);
+                    }
+
+                    @Override
+                    public byte[] getData() {
+                        return payload;
+                    }
+
+                    @Override
+                    public String getChannel() {
+                        return channel.key().asString();
+                    }
+                }));
+    }
+
+    @Override
+    public void placeholderSetupHook() {
+        injector.getSingleton(FandPlaceholderExpansion.class).register();
+    }
+}

--- a/fand/src/main/java/net/skinsrestorer/fand/SRFandLogger.java
+++ b/fand/src/main/java/net/skinsrestorer/fand/SRFandLogger.java
@@ -1,0 +1,54 @@
+/*
+ * SkinsRestorer
+ * Copyright (C) 2026  SkinsRestorer Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.skinsrestorer.fand;
+
+import net.skinsrestorer.shared.log.SRLogLevel;
+import net.skinsrestorer.shared.log.SRPlatformLogger;
+import org.slf4j.Logger;
+
+import java.util.Objects;
+
+public final class SRFandLogger implements SRPlatformLogger {
+    private final Logger logger;
+
+    public SRFandLogger(Logger logger) {
+        this.logger = Objects.requireNonNull(logger, "logger");
+    }
+
+    @Override
+    public void log(SRLogLevel level, String message) {
+        log(level, message, null);
+    }
+
+    @Override
+    public void log(SRLogLevel level, String message, Throwable throwable) {
+        if (throwable == null) {
+            switch (level) {
+                case INFO -> logger.info(message);
+                case WARNING -> logger.warn(message);
+                case SEVERE -> logger.error(message);
+            }
+            return;
+        }
+        switch (level) {
+            case INFO -> logger.info(message, throwable);
+            case WARNING -> logger.warn(message, throwable);
+            case SEVERE -> logger.error(message, throwable);
+        }
+    }
+}

--- a/fand/src/main/java/net/skinsrestorer/fand/SkinApplierFand.java
+++ b/fand/src/main/java/net/skinsrestorer/fand/SkinApplierFand.java
@@ -1,0 +1,62 @@
+/*
+ * SkinsRestorer
+ * Copyright (C) 2026  SkinsRestorer Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.skinsrestorer.fand;
+
+import io.fand.api.entity.Player;
+import io.fand.api.player.PlayerSkin;
+import lombok.RequiredArgsConstructor;
+import net.skinsrestorer.api.property.SkinProperty;
+import net.skinsrestorer.fand.placeholder.FandPlaceholderExpansion;
+import net.skinsrestorer.shared.api.SkinApplierAccess;
+import net.skinsrestorer.shared.api.event.EventBusImpl;
+import net.skinsrestorer.shared.api.event.SkinApplyEventImpl;
+
+import javax.inject.Inject;
+
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public final class SkinApplierFand implements SkinApplierAccess<Player> {
+    private final SRFandAdapter adapter;
+    private final EventBusImpl eventBus;
+    private final FandPlaceholderExpansion placeholders;
+
+    @Override
+    public void applySkin(Player player, SkinProperty property) {
+        if (!player.online()) {
+            return;
+        }
+        adapter.runAsync(() -> {
+            SkinApplyEventImpl applyEvent = new SkinApplyEventImpl(player, property);
+            eventBus.callEvent(applyEvent);
+            placeholders.refreshSkinNameAfterChange(player);
+            if (applyEvent.isCancelled()) {
+                return;
+            }
+            SkinProperty applied = applyEvent.getProperty();
+            adapter.runSyncToPlayer(
+                    adapter.getPlayerForScheduling(player),
+                    () -> {
+                        if (player.online()) {
+                            player.setSkin(applied.getValue().isBlank()
+                                    ? null
+                                    : new PlayerSkin(applied.getValue(), applied.getSignature()));
+                            placeholders.refreshTextureAfterSkinChange(player, applied);
+                        }
+                    });
+        });
+    }
+}

--- a/fand/src/main/java/net/skinsrestorer/fand/command/FandCommandManager.java
+++ b/fand/src/main/java/net/skinsrestorer/fand/command/FandCommandManager.java
@@ -1,0 +1,63 @@
+/*
+ * SkinsRestorer
+ * Copyright (C) 2026  SkinsRestorer Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.skinsrestorer.fand.command;
+
+import io.fand.api.command.CommandRegistry;
+import io.fand.api.command.CommandSender;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.incendo.cloud.CommandManager;
+import org.incendo.cloud.SenderMapper;
+import org.incendo.cloud.SenderMapperHolder;
+import org.incendo.cloud.execution.ExecutionCoordinator;
+import org.slf4j.Logger;
+
+public final class FandCommandManager<C> extends CommandManager<C>
+        implements SenderMapperHolder<CommandSender, C> {
+    private final SenderMapper<CommandSender, C> senderMapper;
+
+    @SuppressWarnings("this-escape")
+    public FandCommandManager(
+            CommandRegistry commandRegistry,
+            ExecutionCoordinator<C> executionCoordinator,
+            SenderMapper<CommandSender, C> senderMapper,
+            Logger logger
+    ) {
+        super(executionCoordinator, new FandCommandRegistrationHandler<>(commandRegistry));
+        this.senderMapper = senderMapper;
+        ((FandCommandRegistrationHandler<C>) commandRegistrationHandler()).initialize(this);
+        parameterInjectorRegistry().registerInjector(
+                CommandSender.class,
+                (context, annotations) -> senderMapper.reverse(context.sender()));
+        registerDefaultExceptionHandlers(
+                triplet -> senderMapper.reverse(triplet.first().sender()).sendMessage(Component.text(
+                        triplet.first().formatCaption(triplet.second(), triplet.third()),
+                        NamedTextColor.RED)),
+                pair -> logger.error("Failed to execute SkinsRestorer command", pair.second()));
+    }
+
+    @Override
+    public boolean hasPermission(C sender, String permission) {
+        return senderMapper.reverse(sender).can(permission);
+    }
+
+    @Override
+    public SenderMapper<CommandSender, C> senderMapper() {
+        return senderMapper;
+    }
+}

--- a/fand/src/main/java/net/skinsrestorer/fand/command/FandCommandRegistrationHandler.java
+++ b/fand/src/main/java/net/skinsrestorer/fand/command/FandCommandRegistrationHandler.java
@@ -1,0 +1,83 @@
+/*
+ * SkinsRestorer
+ * Copyright (C) 2026  SkinsRestorer Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.skinsrestorer.fand.command;
+
+import io.fand.api.command.Arguments;
+import io.fand.api.command.CommandContext;
+import io.fand.api.command.CommandRegistry;
+import org.incendo.cloud.Command;
+import org.incendo.cloud.component.CommandComponent;
+import org.incendo.cloud.internal.CommandRegistrationHandler;
+import org.incendo.cloud.suggestion.Suggestion;
+import org.incendo.cloud.util.StringUtils;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+final class FandCommandRegistrationHandler<C> implements CommandRegistrationHandler<C> {
+    private final CommandRegistry commandRegistry;
+    private final Set<String> registeredRoots = new HashSet<>();
+    private FandCommandManager<C> manager;
+
+    FandCommandRegistrationHandler(CommandRegistry commandRegistry) {
+        this.commandRegistry = Objects.requireNonNull(commandRegistry, "commandRegistry");
+    }
+
+    void initialize(FandCommandManager<C> manager) {
+        this.manager = manager;
+    }
+
+    @Override
+    public boolean registerCommand(Command<C> command) {
+        CommandComponent<C> root = command.rootComponent();
+        if (!registeredRoots.add(root.name())) {
+            return true;
+        }
+        commandRegistry.register(root.name(), builder -> {
+            builder.namespace("skinsrestorer").aliases(root.alternativeAliases());
+            builder.executes(context -> execute(root.name(), context));
+            builder.argument("arguments", Arguments.greedyString().asOptional(), branch -> branch
+                    .executes(context -> execute(root.name(), context))
+                    .suggests(context -> suggest(root.name(), context)));
+        });
+        return true;
+    }
+
+    private void execute(String root, CommandContext context) {
+        manager.commandExecutor().executeCommand(
+                manager.senderMapper().map(context.sender()),
+                commandInput(root, context));
+    }
+
+    private java.util.List<String> suggest(String root, CommandContext context) {
+        String input = commandInput(root, context);
+        var suggestions = manager.suggestionFactory().suggestImmediately(
+                manager.senderMapper().map(context.sender()),
+                input);
+        return suggestions.list().stream()
+                .map(Suggestion::suggestion)
+                .map(suggestion -> StringUtils.trimBeforeLastSpace(suggestion, suggestions.commandInput()))
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    private static String commandInput(String root, CommandContext context) {
+        return context.args().isEmpty() ? root : root + " " + String.join(" ", context.args());
+    }
+}

--- a/fand/src/main/java/net/skinsrestorer/fand/gui/FandGUI.java
+++ b/fand/src/main/java/net/skinsrestorer/fand/gui/FandGUI.java
@@ -1,0 +1,100 @@
+/*
+ * SkinsRestorer
+ * Copyright (C) 2026  SkinsRestorer Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.skinsrestorer.fand.gui;
+
+import io.fand.api.Fand;
+import io.fand.api.entity.Player;
+import io.fand.api.gui.Gui;
+import io.fand.api.gui.GuiClick;
+import io.fand.api.item.ItemStack;
+import io.fand.api.item.component.ItemProfile;
+import io.fand.api.plugin.PluginContext;
+import lombok.RequiredArgsConstructor;
+import net.kyori.adventure.key.Key;
+import net.skinsrestorer.fand.wrapper.FandComponentHelper;
+import net.skinsrestorer.fand.wrapper.WrapperFand;
+import net.skinsrestorer.shared.gui.ActionDataCallback;
+import net.skinsrestorer.shared.gui.ClickEventType;
+import net.skinsrestorer.shared.gui.SRInventory;
+import net.skinsrestorer.shared.utils.SRHelpers;
+
+import javax.inject.Inject;
+import java.util.Map;
+
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public final class FandGUI {
+    private final PluginContext context;
+    private final ActionDataCallback actionDataCallback;
+    private final WrapperFand wrapper;
+
+    public void open(Player player, SRInventory source) {
+        Gui.Builder builder = Gui.chest(source.rows(), FandComponentHelper.deserialize(source.title()));
+        for (int slot = 0; slot < source.rows() * 9; slot++) {
+            builder.protectedSlot(slot);
+        }
+        source.items().forEach((slot, item) -> {
+            builder.item(slot, createItem(item));
+            if (!item.clickHandlers().isEmpty()) {
+                builder.handler(slot, click -> handleClick(click, item.clickHandlers()));
+            }
+        });
+        context.guis().open(player, builder.build());
+    }
+
+    private ItemStack createItem(SRInventory.Item item) {
+        String itemId = switch (item.materialType()) {
+            case DIRT -> "minecraft:dirt";
+            case SKULL -> "minecraft:player_head";
+            case ARROW -> "minecraft:arrow";
+            case BARRIER -> "minecraft:barrier";
+            case BOOKSHELF -> "minecraft:bookshelf";
+            case ENDER_EYE -> "minecraft:ender_eye";
+            case ENCHANTING_TABLE -> "minecraft:enchanting_table";
+        };
+        var type = Fand.server().itemType(Key.key(itemId))
+                .orElseThrow(() -> new IllegalStateException("Unknown Fand item type: " + itemId));
+        ItemStack stack = new ItemStack(type, 1)
+                .withCustomName(FandComponentHelper.deserialize(item.displayName()))
+                .withLore(item.lore().stream().map(FandComponentHelper::deserialize).toList());
+        if (item.enchantmentGlow()) {
+            stack = stack.withEnchantmentGlintOverride(true);
+        }
+        if (item.textureHash().isPresent()) {
+            var property = ItemProfile.Property.unsigned(
+                    "textures",
+                    SRHelpers.encodeHashToTexturesValue(item.textureHash().orElseThrow()));
+            stack = stack.withProfile(new ItemProfile(null, null, java.util.List.of(property), null, null, null, null));
+        }
+        return stack;
+    }
+
+    private void handleClick(
+            GuiClick click,
+            Map<ClickEventType, SRInventory.ClickEventAction> handlers
+    ) {
+        SRInventory.ClickEventAction action = handlers.get(switch (click.clickType()) {
+            case PICKUP -> ClickEventType.LEFT;
+            case PICKUP_HALF -> ClickEventType.RIGHT;
+            case QUICK_MOVE -> ClickEventType.SHIFT_LEFT;
+            default -> ClickEventType.OTHER;
+        });
+        if (action != null) {
+            actionDataCallback.handle(wrapper.player(click.player()), action);
+        }
+    }
+}

--- a/fand/src/main/java/net/skinsrestorer/fand/placeholder/FandPlaceholderExpansion.java
+++ b/fand/src/main/java/net/skinsrestorer/fand/placeholder/FandPlaceholderExpansion.java
@@ -1,0 +1,267 @@
+/*
+ * SkinsRestorer
+ * Copyright (C) 2026  SkinsRestorer Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.skinsrestorer.fand.placeholder;
+
+import io.fand.api.Fand;
+import io.fand.api.entity.Player;
+import io.fand.api.event.player.PlayerJoinEvent;
+import io.fand.api.event.player.PlayerQuitEvent;
+import io.fand.api.placeholder.PlaceholderProvider;
+import io.fand.api.plugin.PluginContext;
+import lombok.RequiredArgsConstructor;
+import net.skinsrestorer.api.PropertyUtils;
+import net.skinsrestorer.api.SkinsRestorerProvider;
+import net.skinsrestorer.api.property.SkinIdentifier;
+import net.skinsrestorer.api.property.SkinProperty;
+import net.skinsrestorer.fand.SRFandAdapter;
+import net.skinsrestorer.fand.wrapper.WrapperFand;
+import net.skinsrestorer.shared.storage.HardcodedSkins;
+import org.jspecify.annotations.Nullable;
+
+import javax.inject.Inject;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public final class FandPlaceholderExpansion {
+    private static final String ERROR_MESSAGE = "Error";
+    private static final String NAMESPACE = "skinsrestorer";
+    private static final String PREFIX = NAMESPACE + "_";
+    private static final long CACHE_TTL_NANOS = TimeUnit.SECONDS.toNanos(30);
+    private static final TextureData STEVE_TEXTURE = TextureData.from(HardcodedSkins.STEVE.getProperty());
+    private static final TextureData ALEX_TEXTURE = TextureData.from(HardcodedSkins.ALEX.getProperty());
+
+    private final PluginContext context;
+    private final SRFandAdapter adapter;
+    private final WrapperFand wrapper;
+    private final ConcurrentHashMap<UUID, CachedSkin> skinNames = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<UUID, TextureData> textures = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<UUID, SkinProperty> requestedTextures = new ConcurrentHashMap<>();
+    private final Set<UUID> activePlayers = ConcurrentHashMap.newKeySet();
+    private final Set<UUID> refreshes = ConcurrentHashMap.newKeySet();
+    private final Set<UUID> textureRefreshes = ConcurrentHashMap.newKeySet();
+
+    public void register() {
+        context.placeholders().register(NAMESPACE, PlaceholderProvider.contextual((placeholderContext, identifier) -> {
+            Player player = placeholderContext.targetOptional().orElse(placeholderContext.viewer());
+            return resolve(player, identifier);
+        }));
+        context.events().subscribe(PlayerJoinEvent.class, event -> track(event.player()));
+        context.events().subscribe(PlayerQuitEvent.class, event -> untrack(event.player().uniqueId()));
+        Fand.server().players().forEach(this::track);
+    }
+
+    private @Nullable String resolve(@Nullable Player player, String identifier) {
+        String normalized = identifier.toLowerCase(Locale.ROOT);
+        if (!normalized.startsWith(PREFIX)) {
+            return null;
+        }
+        String params = normalized.substring(PREFIX.length());
+        if (params.startsWith("skin_name")) {
+            return resolveSkinName(player, params);
+        }
+        if (params.startsWith("texture_url")) {
+            return resolveTexture(player, params, true);
+        }
+        if (params.startsWith("texture_id")) {
+            return resolveTexture(player, params, false);
+        }
+        return null;
+    }
+
+    private String resolveSkinName(@Nullable Player player, String params) {
+        if (player == null) {
+            return ERROR_MESSAGE;
+        }
+        if (!track(player)) {
+            return fallbackSkinName(player, params);
+        }
+        UUID playerId = player.uniqueId();
+        CachedSkin cached = skinNames.get(playerId);
+        if (cached == null || cached.expired()) {
+            refresh(playerId);
+        }
+        Optional<SkinIdentifier> skin = cached == null ? Optional.empty() : cached.skin();
+        if (skin.isPresent()) {
+            return skin.orElseThrow().getIdentifier();
+        }
+        return fallbackSkinName(player, params);
+    }
+
+    private static String fallbackSkinName(Player player, String params) {
+        return switch (params) {
+            case "skin_name_or_empty" -> "";
+            case "skin_name_or_player_name" -> player.name();
+            default -> ERROR_MESSAGE;
+        };
+    }
+
+    private String resolveTexture(@Nullable Player player, String params, boolean url) {
+        if (player == null) {
+            return ERROR_MESSAGE;
+        }
+        if (!track(player)) {
+            return fallbackTexture(params, url);
+        }
+        Optional<SkinProperty> property = adapter.getSkinProperty(wrapper.player(player));
+        if (property.isPresent()) {
+            SkinProperty current = property.orElseThrow();
+            TextureData cached = textures.get(player.uniqueId());
+            if (cached != null && cached.matches(current)) {
+                return cached.value(url);
+            }
+            refreshTexture(player.uniqueId(), current);
+        } else {
+            clearTexture(player.uniqueId());
+        }
+        return fallbackTexture(params, url);
+    }
+
+    private static String fallbackTexture(String params, boolean url) {
+        String suffix = params.substring(url ? "texture_url".length() : "texture_id".length());
+        return switch (suffix) {
+            case "_or_empty" -> "";
+            case "_or_steve" -> STEVE_TEXTURE.value(url);
+            case "_or_alex" -> ALEX_TEXTURE.value(url);
+            default -> ERROR_MESSAGE;
+        };
+    }
+
+    private void refresh(UUID playerId) {
+        if (!refreshes.add(playerId)) {
+            return;
+        }
+        adapter.runAsync(() -> {
+            try {
+                refreshNow(playerId);
+            } finally {
+                refreshes.remove(playerId);
+            }
+        });
+    }
+
+    public void refreshSkinNameAfterChange(Player player) {
+        adapter.runAsync(() -> {
+            if (track(player)) {
+                refreshNow(player.uniqueId());
+            }
+        });
+    }
+
+    public void refreshTextureAfterSkinChange(Player player, SkinProperty property) {
+        if (!player.online()) {
+            return;
+        }
+        activePlayers.add(player.uniqueId());
+        if (property.getValue().isBlank()) {
+            clearTexture(player.uniqueId());
+        } else {
+            refreshTexture(player.uniqueId(), property);
+        }
+    }
+
+    private void refreshNow(UUID playerId) {
+        Optional<SkinIdentifier> skin = SkinsRestorerProvider.get()
+                .getPlayerStorage()
+                .getSkinIdOfPlayer(playerId);
+        if (activePlayers.contains(playerId)) {
+            skinNames.put(playerId, new CachedSkin(skin, System.nanoTime()));
+        }
+    }
+
+    private boolean track(Player player) {
+        if (!player.online()) {
+            return false;
+        }
+        if (activePlayers.add(player.uniqueId())) {
+            refresh(player.uniqueId());
+            adapter.getSkinProperty(wrapper.player(player))
+                    .ifPresent(property -> refreshTexture(player.uniqueId(), property));
+        }
+        return true;
+    }
+
+    private void untrack(UUID playerId) {
+        activePlayers.remove(playerId);
+        skinNames.remove(playerId);
+        clearTexture(playerId);
+    }
+
+    private void refreshTexture(UUID playerId, SkinProperty property) {
+        requestedTextures.put(playerId, property);
+        if (!textureRefreshes.add(playerId)) {
+            return;
+        }
+        adapter.runAsync(() -> {
+            SkinProperty requested = requestedTextures.get(playerId);
+            try {
+                if (requested != null) {
+                    TextureData parsed = TextureData.from(requested);
+                    if (activePlayers.contains(playerId) && requested.equals(requestedTextures.get(playerId))) {
+                        textures.put(playerId, parsed);
+                    }
+                }
+            } catch (RuntimeException invalidTexture) {
+                requestedTextures.remove(playerId, requested);
+                textures.remove(playerId);
+            } finally {
+                textureRefreshes.remove(playerId);
+                SkinProperty latest = requestedTextures.get(playerId);
+                TextureData cached = textures.get(playerId);
+                if (activePlayers.contains(playerId)
+                        && latest != null
+                        && (cached == null || !cached.matches(latest))) {
+                    refreshTexture(playerId, latest);
+                }
+            }
+        });
+    }
+
+    private void clearTexture(UUID playerId) {
+        requestedTextures.remove(playerId);
+        textures.remove(playerId);
+    }
+
+    private record CachedSkin(Optional<SkinIdentifier> skin, long loadedAtNanos) {
+        private boolean expired() {
+            return System.nanoTime() - loadedAtNanos >= CACHE_TTL_NANOS;
+        }
+    }
+
+    private record TextureData(String skinValue, String url, String hash) {
+        private static TextureData from(SkinProperty property) {
+            var skin = PropertyUtils.getSkinProfileData(property).getTextures().getSKIN();
+            return new TextureData(
+                    property.getValue(),
+                    skin.getUrl(),
+                    skin.getTextureHash());
+        }
+
+        private boolean matches(SkinProperty property) {
+            return skinValue.equals(property.getValue());
+        }
+
+        private String value(boolean fullUrl) {
+            return fullUrl ? url : hash;
+        }
+    }
+}

--- a/fand/src/main/java/net/skinsrestorer/fand/wrapper/FandComponentHelper.java
+++ b/fand/src/main/java/net/skinsrestorer/fand/wrapper/FandComponentHelper.java
@@ -15,23 +15,17 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-package net.skinsrestorer.shared.info;
+package net.skinsrestorer.fand.wrapper;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
+import net.skinsrestorer.shared.subjects.messages.ComponentString;
 
-@Getter
-@RequiredArgsConstructor
-public enum Platform {
-    BUKKIT("Bukkit", PlatformType.SERVER),
-    FAND("Fand", PlatformType.SERVER),
-    BUNGEE_CORD("BungeeCord", PlatformType.PROXY),
-    VELOCITY("Velocity", PlatformType.PROXY);
+public final class FandComponentHelper {
+    public static Component deserialize(ComponentString component) {
+        return GsonComponentSerializer.gson().deserialize(component.jsonString());
+    }
 
-    private final String friendlyName;
-    private final PlatformType platformType;
-
-    public String getPlatformDescription() {
-        return "%s %s".formatted(friendlyName, platformType.getFriendlyName());
+    private FandComponentHelper() {
     }
 }

--- a/fand/src/main/java/net/skinsrestorer/fand/wrapper/WrapperCommandSender.java
+++ b/fand/src/main/java/net/skinsrestorer/fand/wrapper/WrapperCommandSender.java
@@ -1,0 +1,46 @@
+/*
+ * SkinsRestorer
+ * Copyright (C) 2026  SkinsRestorer Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.skinsrestorer.fand.wrapper;
+
+import io.fand.api.command.CommandSender;
+import lombok.NonNull;
+import lombok.experimental.SuperBuilder;
+import net.skinsrestorer.shared.subjects.AbstractSRCommandSender;
+import net.skinsrestorer.shared.subjects.messages.ComponentString;
+import net.skinsrestorer.shared.subjects.permissions.Permission;
+import net.skinsrestorer.shared.utils.Tristate;
+
+@SuperBuilder
+public class WrapperCommandSender extends AbstractSRCommandSender {
+    protected final @NonNull CommandSender sender;
+
+    @Override
+    public <S> S getAs(Class<S> senderClass) {
+        return senderClass.cast(sender);
+    }
+
+    @Override
+    public void sendMessage(ComponentString messageJson) {
+        sender.sendMessage(FandComponentHelper.deserialize(messageJson));
+    }
+
+    @Override
+    public boolean hasPermission(Permission permission) {
+        return permission.checkPermission(node -> Tristate.fromBoolean(sender.can(node)));
+    }
+}

--- a/fand/src/main/java/net/skinsrestorer/fand/wrapper/WrapperFand.java
+++ b/fand/src/main/java/net/skinsrestorer/fand/wrapper/WrapperFand.java
@@ -1,0 +1,65 @@
+/*
+ * SkinsRestorer
+ * Copyright (C) 2026  SkinsRestorer Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.skinsrestorer.fand.wrapper;
+
+import ch.jalu.configme.SettingsManager;
+import io.fand.api.command.CommandSender;
+import io.fand.api.entity.Player;
+import lombok.RequiredArgsConstructor;
+import net.skinsrestorer.fand.SRFandAdapter;
+import net.skinsrestorer.shared.subjects.SRCommandSender;
+import net.skinsrestorer.shared.subjects.SRServerPlayer;
+import net.skinsrestorer.shared.subjects.SRSubjectWrapper;
+import net.skinsrestorer.shared.subjects.messages.SkinsRestorerLocale;
+
+import javax.inject.Inject;
+
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public final class WrapperFand implements SRSubjectWrapper<CommandSender, Player, SRServerPlayer> {
+    private final SettingsManager settings;
+    private final SkinsRestorerLocale locale;
+    private final SRFandAdapter adapter;
+
+    @Override
+    public SRCommandSender commandSender(CommandSender sender) {
+        if (sender instanceof Player player) {
+            return player(player);
+        }
+        return WrapperCommandSender.builder()
+                .sender(sender)
+                .settings(settings)
+                .locale(locale)
+                .build();
+    }
+
+    @Override
+    public SRServerPlayer player(Player player) {
+        return WrapperPlayer.builder()
+                .player(player)
+                .sender(player)
+                .adapter(adapter)
+                .settings(settings)
+                .locale(locale)
+                .build();
+    }
+
+    @Override
+    public CommandSender unwrap(SRCommandSender sender) {
+        return sender.getAs(CommandSender.class);
+    }
+}

--- a/fand/src/main/java/net/skinsrestorer/fand/wrapper/WrapperPlayer.java
+++ b/fand/src/main/java/net/skinsrestorer/fand/wrapper/WrapperPlayer.java
@@ -1,0 +1,83 @@
+/*
+ * SkinsRestorer
+ * Copyright (C) 2026  SkinsRestorer Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.skinsrestorer.fand.wrapper;
+
+import io.fand.api.Fand;
+import io.fand.api.entity.Player;
+import io.fand.api.visibility.VanishService;
+import lombok.NonNull;
+import lombok.experimental.SuperBuilder;
+import net.skinsrestorer.fand.SRFandAdapter;
+import net.skinsrestorer.shared.config.MessageConfig;
+import net.skinsrestorer.shared.subjects.SRPlayer;
+import net.skinsrestorer.shared.subjects.SRServerPlayer;
+import net.skinsrestorer.shared.utils.LocaleParser;
+
+import java.util.Locale;
+import java.util.UUID;
+
+@SuperBuilder
+public class WrapperPlayer extends WrapperCommandSender implements SRServerPlayer {
+    private final @NonNull Player player;
+    private final @NonNull SRFandAdapter adapter;
+
+    @Override
+    public <S> S getAs(Class<S> senderClass) {
+        if (senderClass.isAssignableFrom(Player.class)) {
+            return senderClass.cast(player);
+        }
+        return super.getAs(senderClass);
+    }
+
+    @Override
+    public Locale getLocale() {
+        if (!settings.getProperty(MessageConfig.PER_ISSUER_LOCALE)) {
+            return settings.getProperty(MessageConfig.LOCALE);
+        }
+        return LocaleParser.parseLocale(player.clientSettings().locale())
+                .orElseGet(() -> settings.getProperty(MessageConfig.LOCALE));
+    }
+
+    @Override
+    public UUID getUniqueId() {
+        return player.uniqueId();
+    }
+
+    @Override
+    public String getName() {
+        return player.name();
+    }
+
+    @Override
+    public boolean canSee(SRPlayer other) {
+        Player otherPlayer = other.getAs(Player.class);
+        return Fand.server().services().service(VanishService.class)
+                .map(vanish -> vanish.canSee(player, otherPlayer))
+                .orElseGet(() -> otherPlayer.visibleInPlayerList(player));
+    }
+
+    @Override
+    public void closeInventory() {
+        player.closeInventory();
+    }
+
+    @Override
+    public void sendToMessageChannel(byte[] data) {
+        adapter.sendPluginMessage(player, data);
+    }
+}

--- a/fand/src/main/resources/fand-plugin.json
+++ b/fand/src/main/resources/fand-plugin.json
@@ -1,0 +1,14 @@
+{
+  "id": "skinsrestorer",
+  "version": "${version}",
+  "mainClass": "net.skinsrestorer.fand.SRFandBootstrap",
+  "description": "${description}",
+  "website": "${url}",
+  "license": "GPL-3.0-or-later",
+  "apiVersion": "0.1.1",
+  "authors": ["SkinsRestorer Team", "MC20018"],
+  "depends": [],
+  "loadAfter": [],
+  "loadBefore": [],
+  "permissions": []
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,7 @@ maven_version=15.12.5-SNAPSHOT
 paperVersion=1.8-26.1.1
 velocityVersion=3.0-3.4
 waterfallVersion=1.17-1.21
+fandVersion=0.8.2+build.2
 
 # Minecraft properties
 modMcVersion=26.2

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -46,6 +46,7 @@ include("multiver:viaversion")
 setupSRSubproject("bukkit")
 setupSRSubproject("bungee")
 setupSRSubproject("velocity")
+include("fand")
 
 setupSubproject("skinsrestorer-mod-common") {
     projectDir = file("mod/common")


### PR DESCRIPTION
Add a dedicated Fand platform module and wire its artifact into the Gradle build, CI uploads, release publishing, and shared platform metadata. Target Fand 0.8.2+build.2 and reject older runtimes that do not provide the required login-profile and GUI behavior.

Integrate plugin lifecycle, commands, permissions, events, messaging, Adventure components, sounds, native GUI handling, authenticated login profiles, dynamic skin application and clearing, proxy detection, and native VanishService visibility checks.

Expose SkinsRestorer placeholders through Fand without synchronous storage lookups. Cache skin names and decoded texture data asynchronously, invalidate caches after skin changes, and guard refresh tasks against logout and stale-session races.